### PR TITLE
[CFDP-429] website-html-content-item

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -114,6 +114,9 @@ ROCK_MAPPINGS:
     WebsiteBlockItem:
       EntityType: ContentChannelItem
       ContentChannelTypeId: [15]
+    WebsiteHtmlBlockItem:
+      EntityType: ContentChannelItem
+      ContentChannelTypeId: [25]
     WebsiteGroupItem:
       EntityType: ContentChannelItem
       ContentChannelTypeId: [16]

--- a/src/data/content-item/resolver.js
+++ b/src/data/content-item/resolver.js
@@ -15,6 +15,7 @@ import {
 
 import * as EventContentItem from '../event-content-item'
 import * as WebsiteContentItem from '../website-content-item'
+import * as WebsiteHtmlContentItem from '../website-html-content-item'
 import * as WebsiteFeature from '../website-feature'
 import * as WebsiteGroupContentItem from '../website-group-content-item'
 import * as WebsitePagesContentItem from '../website-pages-content-item'
@@ -143,6 +144,7 @@ const resolver = {
   },
   ...EventContentItem.resolver,
   ...WebsiteContentItem.resolver,
+  ...WebsiteHtmlContentItem.resolver,
   ...WebsiteFeature.resolver,
   ...WebsiteGroupContentItem.resolver,
   ...WebsitePagesContentItem.resolver,

--- a/src/data/content-item/schema.js
+++ b/src/data/content-item/schema.js
@@ -3,6 +3,7 @@ import gql from 'graphql-tag'
 
 import * as EventContentItem from '../event-content-item'
 import * as WebsiteContentItem from '../website-content-item'
+import * as WebsiteHtmlContentItem from '../website-html-content-item'
 import * as WebsiteFeature from '../website-feature'
 import * as WebsiteGroupContentItem from '../website-group-content-item'
 import * as WebsiteNavigation from '../website-navigation'
@@ -11,6 +12,7 @@ import * as WebsitePagesContentItem from '../website-pages-content-item'
 export default gql`
   ${ContentItem.schema}
   ${EventContentItem.schema}
+  ${WebsiteHtmlContentItem.schema}
   ${WebsiteFeature.schema}
   ${WebsiteGroupContentItem.schema}
   ${WebsitePagesContentItem.schema}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -40,6 +40,7 @@ import * as Browse from './browse'
 // Localized Modules
 import * as WebsitePagesContentItem from './website-pages-content-item'
 import * as WebsiteContentItem from './website-content-item'
+import * as WebsiteHtmlContentItem from './website-html-content-item'
 import * as WebsiteGroupContentItem from './website-group-content-item'
 import * as WebsiteNavigation from './website-navigation'
 import * as WebsiteFeature from './website-feature'
@@ -100,6 +101,9 @@ const data = {
   },
   WebsiteContentItem: {
     dataSource: WebsiteContentItem.dataSource
+  },
+  WebsiteHtmlContentItem: {
+    dataSource: WebsiteHtmlContentItem.dataSource
   },
   WebsiteGroupContentItem: {
     dataSource: WebsiteGroupContentItem.dataSource

--- a/src/data/website-html-content-item/data-source.js
+++ b/src/data/website-html-content-item/data-source.js
@@ -1,0 +1,3 @@
+import { ContentItem, ContentChannel } from '@apollosproject/data-connector-rock';
+
+export default ContentItem.dataSource;

--- a/src/data/website-html-content-item/index.js
+++ b/src/data/website-html-content-item/index.js
@@ -1,0 +1,5 @@
+import schema from './schema';
+import resolver from './resolver';
+import dataSource from './data-source';
+
+export { schema, resolver, dataSource };

--- a/src/data/website-html-content-item/resolver.js
+++ b/src/data/website-html-content-item/resolver.js
@@ -1,0 +1,9 @@
+import { ContentItem } from '@apollosproject/data-connector-rock'
+
+const resolver = {
+    WebsiteHtmlBlockItem: {
+        htmlContent: ({ content }) => content
+    }
+}
+
+export default resolver

--- a/src/data/website-html-content-item/schema.js
+++ b/src/data/website-html-content-item/schema.js
@@ -1,0 +1,29 @@
+import { gql } from 'apollo-server'
+
+export default gql`
+    type WebsiteHtmlBlockItem implements ContentItem & Node {
+        id: ID!
+        title(hyphenated: Boolean): String
+        coverImage: ImageMedia
+        images: [ImageMedia]
+        videos: [VideoMedia]
+        audios: [AudioMedia]
+        htmlContent: String
+        summary: String
+        childContentItemsConnection(
+            first: Int
+            after: String
+        ): ContentItemsConnection
+        siblingContentItemsConnection(
+            first: Int
+            after: String
+        ): ContentItemsConnection
+        parentChannel: ContentChannel
+        theme: Theme
+
+        feature: String
+        subtitle: String
+
+    }
+`;
+


### PR DESCRIPTION
## Added New HTML Content Item
Added `website-html-content-item`

This item was created to just pass HTML from Rock and reuses the `content-item` resolvers and schema.