### PR TITLE
Added Custom sanitize-html.js

### DIFF
--- a/src/data/content-item/resolver.js
+++ b/src/data/content-item/resolver.js
@@ -13,6 +13,8 @@ import {
   orderBy,
 } from 'lodash'
 
+import sanitizeHtml from '../sanitize-html'
+
 import * as EventContentItem from '../event-content-item'
 import * as InformationalContentItem from '../informational-content-item'
 import * as WebsiteContentItem from '../website-content-item'
@@ -73,6 +75,7 @@ const titleResolver = {
       )
       .join(' ')
   },
+  htmlContent: ({ content }) => sanitizeHtml(content),
 }
 
 const resolverExtensions = {

--- a/src/data/event-content-item/resolver.js
+++ b/src/data/event-content-item/resolver.js
@@ -14,6 +14,7 @@ import moment from 'moment'
 import momentTz from 'moment-timezone'
 
 import { parseRockKeyValuePairs } from '../utils'
+import sanitizeHtml from '../sanitize-html'
 
 const resolver = {
   EventContentItem: {
@@ -86,7 +87,8 @@ const resolver = {
       }
 
       return []
-    }
+    },
+    htmlContent: ({ content }) => sanitizeHtml(content),
   },
 }
 

--- a/src/data/sanitize-html.js
+++ b/src/data/sanitize-html.js
@@ -1,0 +1,37 @@
+import sanitizeHtml from 'sanitize-html';
+
+const allowedTags = [
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'blockquote',
+  'p',
+  'a',
+  'ul',
+  'ol',
+  'li',
+  'b',
+  'i',
+  'strong',
+  'em',
+  'br',
+  'caption',
+  'img',
+  'div',
+];
+
+const allowedAttributes = {
+  a: ['href', 'target'],
+  img: ['src'],
+};
+
+// A very picky HTML sanitizer
+export default function(dirty) {
+  return sanitizeHtml(dirty, {
+    allowedTags,
+    allowedAttributes,
+  });
+}


### PR DESCRIPTION
### Issue
The `apollos-data-connector-rock` was sanitizing the htmlContent removing the `target` attribute in `<a>` tags removing the ability to open links in a new tab from the HTML content.

### Fix
Override htmlContent in the **resolvers** to use a custom `sanitizeHtml` for `content-item` and `event-content-item`. Allowing the `target` attribute in `<a>` tags.