### PR TITLE
[CFDP-526] Video Url Bug Fix

### DIFF
--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -44,6 +44,6 @@ export const getIdentifierType = (identifier) => {
   for the video file */
 // export const createVideoUrlFromGuid = (uri) => uri
 export const createVideoUrlFromGuid = (uri) =>
-  uri.split('-').length === 5
-    ? `${ApollosConfig.ROCK.FILE_URL}?guid=${uri}`
-    : Utils.enforceProtocol(uri)
+  uri.includes('http')
+    ? Utils.enforceProtocol(uri)
+    : `${ApollosConfig.ROCK.FILE_URL}?guid=${uri}`

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -44,6 +44,6 @@ export const getIdentifierType = (identifier) => {
   for the video file */
 // export const createVideoUrlFromGuid = (uri) => uri
 export const createVideoUrlFromGuid = (uri) =>
-  uri.includes('http')
+  uri.startsWith('http')
     ? Utils.enforceProtocol(uri)
     : `${ApollosConfig.ROCK.FILE_URL}?guid=${uri}`


### PR DESCRIPTION
## Video Url Bug Fix
### Issue
* API was misreading url as a guid in the `createVideoUrlFromGuid` method and creating bad urls.
###
* Updated `createVideoUrlFromGuid` method to look for 'http'., instead of splitting string with '-'.