### PR TITLE
Campus Pastor Email

### DIFF
--- a/src/data/campus/data-source.js
+++ b/src/data/campus/data-source.js
@@ -2,7 +2,7 @@ import {
   Campus as coreCampus,
 } from '@apollosproject/data-connector-rock'
 import ApollosConfig from '@apollosproject/config'
-import { get, upperCase, split } from 'lodash'
+import { get, toUpper, split } from 'lodash'
 import { getIdentifierType } from '../utils'
 
 export default class Campus extends coreCampus.dataSource {
@@ -62,7 +62,7 @@ export default class Campus extends coreCampus.dataSource {
 
   getByName = async (name) => this
     .request()
-    .filter(`toupper(Name) eq '${upperCase(name)}'`)
+    .filter(`toupper(Name) eq '${toUpper(name)}'`)
     .expand('Location')
     .expand('Location/Image')
     .cache({ ttl: 600 }) // ten minutes

--- a/src/data/campus/resolver.js
+++ b/src/data/campus/resolver.js
@@ -88,9 +88,8 @@ const resolver = {
     },
     pastor: async ({ leaderPersonAliasId }, args, { dataSources }) => {
       const person = await dataSources.Person.getFromAliasId(leaderPersonAliasId)
-      const { firstName, lastName, photo: { guid } } = person
 
-      const formattedEmail = `${camelCase(firstName)}.${camelCase(lastName)}@christfellowship.church`
+      const { firstName, lastName, photo: { guid }, email } = person
 
       return {
         firstName,
@@ -98,7 +97,7 @@ const resolver = {
         photo: {
           uri: createImageUrlFromGuid(guid)
         },
-        email: toLower(formattedEmail)
+        email
       }
     },
   },

--- a/src/data/campus/resolver.js
+++ b/src/data/campus/resolver.js
@@ -89,7 +89,7 @@ const resolver = {
     pastor: async ({ leaderPersonAliasId }, args, { dataSources }) => {
       const person = await dataSources.Person.getFromAliasId(leaderPersonAliasId)
 
-      const { firstName, lastName, photo: { guid }, email } = person
+      const { nickName: firstName, lastName, photo: { guid }, email } = person
 
       return {
         firstName,


### PR DESCRIPTION
### Changes/Updates
Changed campus pastor email to use email from `leaderPersonAliasId`, instead of generating them manually. This solves for the incorrect campus pastor email bug.