### PR TITLE
Create AuthenticatedUser.streamChatToken resolver

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -23,7 +23,7 @@ ROCK:
   # This should match the timezone of the Rock server
   # TIMEZONE: "Etc/GMT+5"
   TIMEZONE: "America/New_York"
-  DEEP_LINK_HOST: 
+  DEEP_LINK_HOST:
   ROOT_API_URL: ${ROOT_URL}
   USE_PLUGIN: true
   SHOW_INACTIVE_CONTENT: ${ROCK_SHOW_INACTIVE_CONTENT}
@@ -46,6 +46,13 @@ ALGOLIA:
       - title
       - htmlContent
       - unordered(summary)
+
+# Stream Chat https://getstream.io
+STREAM:
+  CHAT_SECRET: ${STREAM_CHAT_SECRET}
+  CHAT_API_KEY: ${STREAM_CHAT_API_KEY}
+  CHAT_APP_ID: ${STREAM_CHAT_APP_ID}
+
 TWILIO:
   NOTIFY_SID: ${TWILIO_NOTIFY_SID}
   ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}
@@ -254,7 +261,7 @@ PAGE_BUILDER:
     contentChannelId: 72
     buildingBlocks:
       - type: MetadataFeature
-        algorithms: 
+        algorithms:
           - type: CAMPUS_META
             arguments:
               attributeKey: metadata

--- a/config.yml
+++ b/config.yml
@@ -244,6 +244,9 @@ FEATURE_FLAGS:
   LIVE_STREAM_UI:
     securityGroupId: 1014843
     status: "LIVE"
+  LIVE_STREAM_CHAT:
+    securityGroupId: 1014843
+    status: "LIVE"
   NOTIFICATION_CENTER:
     securityGroupId: 1014843 # CFDP Experimental Features
     status: "LIVE"

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "randomcolor": "0.5.3",
     "remove-words": "^0.9.0",
     "sanitize-html": "^1.26.0",
+    "stream-chat": "^1.14.1",
     "twilio": "^3.33.1",
     "url": "^0.11.0",
     "yup": "^0.27.0"

--- a/src/data/auth/resolver.js
+++ b/src/data/auth/resolver.js
@@ -18,8 +18,7 @@ const resolver = {
                 return null;
             }
 
-            const { id: currentUserId } = await Auth.getCurrentPerson();
-            return StreamChat.generateUserToken(currentUserId);
+            return StreamChat.generateUserToken(id);
         },
     },
     Query: {

--- a/src/data/auth/resolver.js
+++ b/src/data/auth/resolver.js
@@ -1,6 +1,4 @@
-import {
-    Auth as coreAuth,
-} from '@apollosproject/data-connector-rock'
+import { Auth as coreAuth } from '@apollosproject/data-connector-rock'
 import ApollosConfig from '@apollosproject/config'
 import { resolverMerge } from '@apollosproject/server-core'
 
@@ -10,6 +8,19 @@ const resolver = {
             dataSources.Auth.requestEmailPin(args),
         changePasswordWithPin: (root, { email, pin, newPassword }, { dataSources }) =>
             dataSources.Auth.changePasswordWithPin({ email, pin, newPassword }),
+    },
+    AuthenticatedUser: {
+        streamChatToken: async ({ id }, args, { dataSources }) => {
+            const { Auth, Flag, StreamChat } = dataSources;
+            const featureFlagStatus = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT');
+
+            if (featureFlagStatus !== 'LIVE') {
+                return null;
+            }
+
+            const { id: currentUserId } = await Auth.getCurrentPerson();
+            return StreamChat.generateUserToken(currentUserId);
+        },
     },
     Query: {
         canAccessExperimentalFeatures: async (root, args, { dataSources }) =>

--- a/src/data/auth/schema.js
+++ b/src/data/auth/schema.js
@@ -12,4 +12,8 @@ export default gql`
     extend type Query {
         canAccessExperimentalFeatures: Boolean
     }
+
+    extend type AuthenticatedUser {
+        streamChatToken: String
+    }
 `

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -60,6 +60,7 @@ import * as PhoneNumber from './phone-number'
 import * as PrayerRequest from './prayer-request'
 import * as Schedule from './schedule'
 import * as Search from './search'
+import * as StreamChat from './stream-chat'
 import * as TwilioNotify from './twilio-notify'
 import * as WebsiteContentItem from './website-content-item'
 import * as WebsiteFeature from './website-feature'
@@ -108,6 +109,7 @@ const data = {
   Search,
   Sharable,
   Sms: TwilioNotify,
+  StreamChat,
   Template,
   Theme,
   TwilioNotify,

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -1,0 +1,36 @@
+import ApollosConfig from "@apollosproject/config";
+import { RESTDataSource } from 'apollo-datasource-rest'
+import { createGlobalId } from "@apollosproject/server-core";
+import { StreamChat as StreamChatClient } from "stream-chat";
+
+const { STREAM } = ApollosConfig;
+const { CHAT_SECRET, CHAT_API_KEY, CHAT_APP_ID } = STREAM;
+
+// Define singleton instance of StreamChatClient
+let chatClient;
+
+if (CHAT_SECRET && CHAT_API_KEY) {
+  chatClient = new StreamChatClient(
+    CHAT_API_KEY,
+    CHAT_SECRET,
+    { region: "us-east-1" }
+  );
+  console.log('[rkd] ✅ Created chat client');
+} else {
+  console.warn(
+    "You are using the Stream Chat dataSource without Stream credentials. To avoid issues, add Stream Chat credentials to your config.yml or remove the Stream Chat dataSource"
+  );
+}
+
+export default class StreamChat extends RESTDataSource {
+  generateUserToken = async (currentPerson) => {
+    const globalId = createGlobalId(currentPerson.id, "AuthenticatedUser"); // -> "AuthenticatedUser:abc123de56789f"
+    const userId = globalId.split(":")[1];
+
+    console.log('[rkd] creating token for userId:', userId);
+    const token = await chatClient.createToken(userId);
+    console.log('[rkd] token:', token);
+
+    return token;
+  };
+}

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -9,13 +9,12 @@ const { CHAT_SECRET, CHAT_API_KEY, CHAT_APP_ID } = STREAM;
 // Define singleton instance of StreamChatClient
 let chatClient;
 
-if (CHAT_SECRET && CHAT_API_KEY) {
+if (CHAT_SECRET && CHAT_API_KEY && !chatClient) {
   chatClient = new StreamChatClient(
     CHAT_API_KEY,
     CHAT_SECRET,
     { region: "us-east-1" }
   );
-  console.log('[rkd] ✅ Created chat client');
 } else {
   console.warn(
     "You are using the Stream Chat dataSource without Stream credentials. To avoid issues, add Stream Chat credentials to your config.yml or remove the Stream Chat dataSource"
@@ -24,13 +23,9 @@ if (CHAT_SECRET && CHAT_API_KEY) {
 
 export default class StreamChat extends RESTDataSource {
   generateUserToken = async (currentPerson) => {
-    const globalId = createGlobalId(currentPerson.id, "AuthenticatedUser"); // -> "AuthenticatedUser:abc123de56789f"
+    const globalId = createGlobalId(currentPerson.id, "AuthenticatedUser");
     const userId = globalId.split(":")[1];
 
-    console.log('[rkd] creating token for userId:', userId);
-    const token = await chatClient.createToken(userId);
-    console.log('[rkd] token:', token);
-
-    return token;
+    return await chatClient.createToken(userId);
   };
 }

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -22,8 +22,8 @@ if (CHAT_SECRET && CHAT_API_KEY && !chatClient) {
 }
 
 export default class StreamChat extends RESTDataSource {
-  generateUserToken = (currentPerson) => {
-    const globalId = createGlobalId(currentPerson.id, "AuthenticatedUser");
+  generateUserToken = (id) => {
+    const globalId = createGlobalId(id, "AuthenticatedUser");
     const userId = globalId.split(":")[1];
 
     return chatClient.createToken(userId);

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -22,10 +22,10 @@ if (CHAT_SECRET && CHAT_API_KEY && !chatClient) {
 }
 
 export default class StreamChat extends RESTDataSource {
-  generateUserToken = async (currentPerson) => {
+  generateUserToken = (currentPerson) => {
     const globalId = createGlobalId(currentPerson.id, "AuthenticatedUser");
     const userId = globalId.split(":")[1];
 
-    return await chatClient.createToken(userId);
+    return chatClient.createToken(userId);
   };
 }

--- a/src/data/stream-chat/index.js
+++ b/src/data/stream-chat/index.js
@@ -1,0 +1,1 @@
+export { default as dataSource } from './data-source';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1224,6 +1224,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.3.1":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.0.0", "@babel/template@^7.4.0":
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.0.tgz#12474e9c077bae585c5d835a95c0b0b790c25c8b"
@@ -1897,6 +1904,11 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
+"@types/seamless-immutable@7.1.12":
+  version "7.1.12"
+  resolved "https://registry.yarnpkg.com/@types/seamless-immutable/-/seamless-immutable-7.1.12.tgz#bab05104e4d4a1ec608d02da121dab0bb149a4e4"
+  integrity sha512-I+Zmx4haxUT6rK1hXmOkUkgmAVrbxZ9rlvm+dXX82ZaGogXLDlnh7ceK/XAkIO7wget+bfIaOu1IvLRPz/DHbA==
+
 "@types/serve-static@*":
   version "1.13.4"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.4.tgz#6662a93583e5a6cabca1b23592eb91e12fa80e7c"
@@ -1909,6 +1921,13 @@
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/ws@^6.0.3":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.4.tgz#7797707c8acce8f76d8c34b370d4645b70421ff1"
+  integrity sha512-PpPrX7SZW9re6+Ha8ojZG4Se8AZXgf0GK6zmfqEuCsY49LFDNXO3SByp44X3dFEqtB73lkCDAdUazhAjVPiNwg==
+  dependencies:
+    "@types/node" "*"
 
 "@types/ws@^7.0.0":
   version "7.2.5"
@@ -2930,6 +2949,11 @@ base64-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.0.tgz#cab1e6118f051095e58b5281aea8c1cd22bfc0e3"
   integrity sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==
 
+base64-js@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.3.1.tgz#58ece8cb75dd07e71ed08c736abc5fac4dbf8df1"
+  integrity sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==
+
 base@^0.11.1:
   version "0.11.2"
   resolved "https://registry.yarnpkg.com/base/-/base-0.11.2.tgz#7bde5ced145b6d551a90db87f83c558b4eb48a8f"
@@ -3291,6 +3315,11 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+chai-arrays@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/chai-arrays/-/chai-arrays-2.2.0.tgz#571479cbc5eca81605ed4eed1e8a2a28552d2a25"
+  integrity sha512-4awrdGI2EH8owJ9I58PXwG4N56/FiM8bsn4CVSNEgr4GKAM6Kq5JPVApUbhUBjDakbZNuRvV7quRSC38PWq/tg==
 
 chalk@^1.1.3:
   version "1.1.3"
@@ -6028,6 +6057,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-ws@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
+  integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -7104,7 +7138,7 @@ jsonwebtoken@^8.1.0:
     ms "^2.1.1"
     semver "^5.6.0"
 
-jsonwebtoken@^8.5.1:
+jsonwebtoken@^8.3.0, jsonwebtoken@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
@@ -9003,6 +9037,11 @@ regenerator-runtime@^0.13.2:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
   integrity sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==
 
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+
 regenerator-transform@^0.14.0:
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/regenerator-transform/-/regenerator-transform-0.14.0.tgz#2ca9aaf7a2c239dd32e4761218425b8c7a86ecaf"
@@ -9382,6 +9421,11 @@ scmp@2.0.0:
   resolved "https://registry.yarnpkg.com/scmp/-/scmp-2.0.0.tgz#247110ef22ccf897b13a3f0abddb52782393cd6a"
   integrity sha1-JHEQ7yLM+JexOj8KvdtSeCOTzWo=
 
+seamless-immutable@^7.1.4:
+  version "7.1.4"
+  resolved "https://registry.yarnpkg.com/seamless-immutable/-/seamless-immutable-7.1.4.tgz#6e9536def083ddc4dea0207d722e0e80d0f372f8"
+  integrity sha512-XiUO1QP4ki4E2PHegiGAlu6r82o5A+6tRh7IkGGTVg/h+UoeX4nFBeCGPOhb4CYjvkqsfm/TUtvOMYC1xmV30A==
+
 semver-diff@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/semver-diff/-/semver-diff-3.1.1.tgz#05f77ce59f325e00e2706afd67bb506ddb1ca32b"
@@ -9728,6 +9772,24 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+stream-chat@^1.14.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/stream-chat/-/stream-chat-1.14.1.tgz#c2e7786e6865647902cf81a43adfa48ff8ae12ba"
+  integrity sha512-1WeTpNqXhDmuOo5QGixBXGASjZYoGbMZIFZ83MzfgsJh0rMoGIR5Hwx+P/qtAffwlSktXxf7+6GKidgSEYcQRw==
+  dependencies:
+    "@babel/runtime" "^7.3.1"
+    "@types/seamless-immutable" "7.1.12"
+    "@types/ws" "^6.0.3"
+    axios "^0.18.1"
+    base64-js "^1.3.1"
+    chai-arrays "^2.0.0"
+    form-data "^2.3.3"
+    isomorphic-ws "^4.0.1"
+    jsonwebtoken "^8.3.0"
+    seamless-immutable "^7.1.4"
+    uuid "^3.3.2"
+    ws "^6.1.3"
 
 stream-events@^1.0.5:
   version "1.0.5"
@@ -10669,7 +10731,7 @@ ws@^5.2.0:
   dependencies:
     async-limiter "~1.0.0"
 
-ws@^6.0.0:
+ws@^6.0.0, ws@^6.1.3:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
   integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==


### PR DESCRIPTION
### Description
Takes the core of @asleepingpanda 's POC work on branch [chat-discovery](https://github.com/christfellowshipchurch/apollos-api/compare/chat-discovery) and alters it to be production ready.

**Specifically, this PR:**
- Adds `stream-chat` dependency
- Adds a feature flag `LIVE_STREAM_CHAT`, accessible only to users in the security group **CFDP Experimental Features** (`1014843`)
- Creates `src/data/stream-chat` to manage `StreamChat` client instance
- Creates `streamChatToken` query resolver on `AuthenticatedUser`

|**The new resolver in action**|
|---|
|![CleanShot 2020-08-26 at 00 05 18@2x](https://user-images.githubusercontent.com/1812955/91254783-3d88a300-e731-11ea-84ad-24ff9bc6161e.jpg)|

### Testing

**Setup**
New `.env` variables are required to initialize the `StreamChat` client.
The keys are:

```
STREAM_CHAT_APP_ID=
STREAM_CHAT_SECRET=
STREAM_CHAT_API_KEY=
```
I can communicate the values via Slack.

**Authentication in local GraphQL playground**
Run the following mutation, and use the resulting `token` as an `"authorization"` HTTP Header value to run queries as an authenticated user.

```graphql
mutation authenticate($identity: String!, $password: String!) {
  authenticate(identity:$identity, password:$password) {
    token
  }
}

# Variables
# {
#  "identity": "<email>",
#  "password": "<password>" 
# }
```

**Steps**
1. Open the local graphql playground
2. If you're not authenticated, follow the steps above
3. Run the following query, and verify you're given a valid `streamChatToken` JWT.
4. For extra credit: copy the JWT value into jwt.io and verify the user id in the decoded token matches yours

```graphql
query {
  currentUser {
    id
    streamChatToken
    profile {
      firstName
      lastName
      photo {
        uri
      }
    }
  }
}
```