### PR TITLE
[Chat] Add authenticatedUser.streamChatRole field and resolver

### DIFF
--- a/src/data/auth/resolver.js
+++ b/src/data/auth/resolver.js
@@ -21,14 +21,14 @@ const resolver = {
 
             return StreamChat.generateUserToken(id);
         },
-        streamChatRole: async ({ id }, args, { dataSources }) => {
+        streamChatRole: async ({ id }, { id: contentId }, { dataSources }) => {
             const { Auth, StreamChat } = dataSources;
 
             const flag = get(ApollosConfig, 'FEATURE_FLAGS.LIVE_STREAM_CHAT', null)
             if (flag && flag.status === "LIVE") {
                 if (flag.securityGroupId) {
                     if (await Auth.isInSecurityGroup(flag.securityGroupId)) {
-                      await StreamChat.addModerator(id);
+                      await StreamChat.addModerator({ contentId, id });
                       return 'MODERATOR';
                     }
                 }

--- a/src/data/auth/schema.js
+++ b/src/data/auth/schema.js
@@ -13,7 +13,13 @@ export default gql`
         canAccessExperimentalFeatures: Boolean
     }
 
+    enum CHAT_ROLES {
+      MODERATOR
+      USER
+    }
+
     extend type AuthenticatedUser {
         streamChatToken: String
+        streamChatRole(id: ID): CHAT_ROLES
     }
 `

--- a/src/data/auth/schema.js
+++ b/src/data/auth/schema.js
@@ -20,6 +20,6 @@ export default gql`
 
     extend type AuthenticatedUser {
         streamChatToken: String
-        streamChatRole(id: ID): CHAT_ROLES
+        streamChatRole(id: ID!): CHAT_ROLES
     }
 `

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -28,4 +28,15 @@ export default class StreamChat extends RESTDataSource {
 
     return chatClient.createToken(userId);
   };
+
+  addModerator = async (id) => {
+    const globalId = createGlobalId(id, "AuthenticatedUser");
+    const userId = globalId.split(":")[1];
+
+    await chatClient.updateUser({
+      id: userId,
+      // role: 'moderator', 
+      role: 'admin', 
+    });
+  }
 }

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -29,14 +29,11 @@ export default class StreamChat extends RESTDataSource {
     return chatClient.createToken(userId);
   };
 
-  addModerator = async (id) => {
+  addModerator = async ({ contentId, id }) => {
     const globalId = createGlobalId(id, "AuthenticatedUser");
     const userId = globalId.split(":")[1];
 
-    await chatClient.updateUser({
-      id: userId,
-      // role: 'moderator', 
-      role: 'admin', 
-    });
+    const channel = chatClient.channel('livestream', contentId);
+    await channel.addModerators([userId]);
   }
 }


### PR DESCRIPTION
**Summary**

This PR adds a new field/query to  `AuthenticatedUser` to return the chat role for the current user (for the given channel). It:

1. Determines if the user is in the configured Security Group for chat moderators.
1. If so, adds the user as  a moderator to the channel in Stream.io, so that the user can make moderation calls in the client.
1. Returns the role to the client, so that the client can update the UI and make moderation calls.

**Discussion**

- There are only two roles returned right now, `MODERATOR` and `USER`. Made this an enum  type so that we can add other roles, e.g. `ADMIN`.

- Right now, a user is globally a moderator or not. We added a content ID param so that, in the future, we could look up the event for a security group attribute and have _event-specific_ moderators. This is not done in this PR.

- Interestingly, we need the content ID param anyway, because _there are no_ global moderators in Stream.io. There are only channel-specific moderators. So we need the content ID (which is the channel ID) anyway to add the user as moderator. There are global admin users, but I figured we do not want to give any users chat admin capabilities.

**Testing**

In Playground—for some reason Apollo Devtools was not working right—get an authentication token to put in the `Authentication` HTTP header.

```gql
mutation authenticate($identity: String!, $password: String!) {
  authenticate(identity: $identity, password: $password) {
    token
  }
}

{
  "identity":"gerard@differential.com",
  "password":"<password>"
}
```

Get a livestream content ID.

```gql
  query getLiveContent {
    liveStreams {
      isLive
      media {
        sources {
          uri
        }
      }
      contentItem {
        id
      }
    }
  }
```

With the content ID, request the new field.

```gql
query {
  currentUser {
    id
    streamChatToken
    streamChatRole(id: "<livestream content ID>")
    profile {
      firstName
      lastName
      photo {
        uri
      }
    }
  }
}
```

Verify that the user is a channel moderator using....?