### PR TITLE
Uses Feature Action schema for Groups Resources

### DIFF
--- a/src/data/groups/schema.js
+++ b/src/data/groups/schema.js
@@ -20,6 +20,10 @@ export const groupSchema = gql`
     title: String
     url: String
     contentChannelItem: String
+    
+    icon: String
+    action: ACTION_FEATURE_ACTION
+    relatedNode: Node
   }
 
   type DateTime {


### PR DESCRIPTION
@burkeshartsis this update matches the `resources` schema to the same Feature Action schema in order to make routing more cohesive on the app.

This PR completely deprecates the OG `resources` schema, but I'm down to keep that supported if need be for the web stuff.

Thoughts?