### PR TITLE
[Chat] Chat Channel ID and Event Metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "apollo-server": "^2.14.2",
     "apollo-server-express": "2.14.2",
     "color": "3.0.0",
+    "crypto-js": "4.0.0",
     "dotenv": "6.0.0",
     "express": "^4.17.0",
     "graphql": "14.6.0",

--- a/src/data/live-stream/schema.js
+++ b/src/data/live-stream/schema.js
@@ -4,6 +4,10 @@ import gql from 'graphql-tag'
 export default gql`
     ${liveSchema}
 
+    extend type LiveStream {
+      chatChannelId: String
+    }
+
     type FloatLeftLiveStream {
         start: String
         isLive: Boolean

--- a/yarn.lock
+++ b/yarn.lock
@@ -3412,6 +3412,11 @@ crypt@0.0.2:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
+crypto-js@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.0.0.tgz#2904ab2677a9d042856a2ea2ef80de92e4a36dcc"
+  integrity sha512-bzHZN8Pn+gS7DQA6n+iUmBfl0hO5DJq++QP3U6uTucDtk/0iGpXd/Gg7CGR0p8tJhofJyaKoWBuJI4eAO00BBg==
+
 crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"


### PR DESCRIPTION
**Summary**

This PR adds a new field to the `LiveStream` type called `chatChannelId`. This moves the channel ID generation from the client to the server, giving us more flexibility in the future should we decide to change the logic. For example, if this isn't unique enough, we can fix it without a new client. Or if livestreams get a proper node ID, we can start using that same value for this field.

**Discussion**

I'm SHA1 hashing the livestream parent ID (e.g. `EventContentItem:1e07e4f2e1b52807e43b2338c73d88ba`), the livestream start time and the end time. SHA1 guarantees some kind of mathy uniqueness and a fixed length.

**Testing**

GraphQL Playground (you may need to be authenticated):

```gql
query getLiveContent {
  liveStreams {
    isLive
    media {
      sources {
        uri
      }
    }
    chatChannelId
    contentItem {
      id
      title
      ... on EventContentItem {
        events {
          id
          start
          end
          name
        }
      }
    }
  }
}
```

**Screenshots**

![image](https://user-images.githubusercontent.com/200488/94276906-d835f680-ff16-11ea-9dd7-ca3c48888bab.png)
