### PR TITLE
[Chat] Add moderator security group and GROUP_CHAT feature flag

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -339,8 +339,6 @@ FEATURE_FEEDS:
       type: PrayerList
       title: Daily Prayer
 
-
-
 FEATURE_FLAGS:
   CHECK_IN:
     status: 'LIVE'
@@ -348,8 +346,11 @@ FEATURE_FLAGS:
     status: 'LIVE'
   HOME_HEADER:
     status: 'LIVE'
+  GROUP_CHAT:
+    securityGroupId: 1052011 # CFDP Feature Flags/Live Stream Chat
   LIVE_STREAM_CHAT:
     securityGroupId: 1052011 # CFDP Feature Flags/Live Stream Chat
+    moderatorGroupId: 1054703 # CFDP Global Event Chat Moderators Group
     status: 'LIVE'
   LIVE_STREAM_UI:
     securityGroupId: 1014843 # CFDP Experimental Features
@@ -362,8 +363,6 @@ FEATURE_FLAGS:
   VOLUNTEER_GROUPS:
     securityGroupId: 1052010 # CFDP Feature Flags/My Dream Teams
     status: 'LIVE'
-  
-  
 
 PAGE_BUILDER:
   locations:

--- a/config.yml
+++ b/config.yml
@@ -350,7 +350,9 @@ FEATURE_FLAGS:
     securityGroupId: 1052011 # CFDP Feature Flags/Live Stream Chat
   LIVE_STREAM_CHAT:
     securityGroupId: 1052011 # CFDP Feature Flags/Live Stream Chat
-    moderatorGroupId: 1054703 # CFDP Global Event Chat Moderators Group
+    status: 'LIVE'
+  LIVE_STREAM_CHAT_MODERATOR:
+    securityGroupId: 1054703 # CFDP Global Event Chat Moderators Group
     status: 'LIVE'
   LIVE_STREAM_UI:
     securityGroupId: 1014843 # CFDP Experimental Features

--- a/src/data/auth/resolver.js
+++ b/src/data/auth/resolver.js
@@ -28,7 +28,7 @@ const resolver = {
         return null;
       }
 
-      if (await StreamChat.currentUserIsGlobalModerator()) {
+      if (await StreamChat.currentUserIsLiveStreamModerator()) {
         await StreamChat.addModerator({ channelId, userId });
         return 'MODERATOR';
       }

--- a/src/data/auth/resolver.js
+++ b/src/data/auth/resolver.js
@@ -3,44 +3,44 @@ import ApollosConfig from '@apollosproject/config'
 import { resolverMerge } from '@apollosproject/server-core'
 
 const resolver = {
-    Mutation: {
-        requestEmailLoginPin: (root, args, { dataSources }) =>
-            dataSources.Auth.requestEmailPin(args),
-        changePasswordWithPin: (root, { email, pin, newPassword }, { dataSources }) =>
-            dataSources.Auth.changePasswordWithPin({ email, pin, newPassword }),
+  Mutation: {
+    requestEmailLoginPin: (root, args, { dataSources }) =>
+      dataSources.Auth.requestEmailPin(args),
+    changePasswordWithPin: (root, { email, pin, newPassword }, { dataSources }) =>
+      dataSources.Auth.changePasswordWithPin({ email, pin, newPassword }),
+  },
+  AuthenticatedUser: {
+    streamChatToken: async ({ id }, args, { dataSources }) => {
+      const { Flag, StreamChat } = dataSources;
+      const featureFlagStatus = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT');
+
+      if (featureFlagStatus !== 'LIVE') {
+        return null;
+      }
+
+      return StreamChat.generateUserToken(id);
     },
-    AuthenticatedUser: {
-        streamChatToken: async ({ id }, args, { dataSources }) => {
-            const { Auth, Flag, StreamChat } = dataSources;
-            const featureFlagStatus = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT');
+    streamChatRole: async ({ id: userId }, { id: channelId }, { dataSources }) => {
+      const { Flag, StreamChat } = dataSources;
+      const featureFlagStatus = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT');
 
-            if (featureFlagStatus !== 'LIVE') {
-                return null;
-            }
+      if (featureFlagStatus !== 'LIVE') {
+        return null;
+      }
 
-            return StreamChat.generateUserToken(id);
-        },
-        streamChatRole: async ({ id: userId }, { id: channelId }, { dataSources }) => {
-            const { Flag, StreamChat } = dataSources;
-            const featureFlagStatus = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT');
+      if (await StreamChat.currentUserIsGlobalModerator()) {
+        await StreamChat.addModerator({ channelId, userId });
+        return 'MODERATOR';
+      }
 
-            if (featureFlagStatus !== 'LIVE') {
-                return null;
-            }
-
-            if (await StreamChat.currentUserIsGlobalModerator()) {
-                await StreamChat.addModerator({ channelId, userId });
-                return 'MODERATOR';
-            }
-
-            await StreamChat.removeModerator({ channelId, userId });
-            return 'USER';
-        },
+      await StreamChat.removeModerator({ channelId, userId });
+      return 'USER';
     },
-    Query: {
-        canAccessExperimentalFeatures: async (root, args, { dataSources }) =>
-            dataSources.Auth.isInSecurityGroup(ApollosConfig.ROCK_MAPPINGS.SECURITY_GROUPS.EXPERIMENTAL_FEATURES),
-    }
+  },
+  Query: {
+    canAccessExperimentalFeatures: async (root, args, { dataSources }) =>
+      dataSources.Auth.isInSecurityGroup(ApollosConfig.ROCK_MAPPINGS.SECURITY_GROUPS.EXPERIMENTAL_FEATURES),
+  }
 }
 
 export default resolverMerge(resolver, coreAuth)

--- a/src/data/stream-chat/data-source.js
+++ b/src/data/stream-chat/data-source.js
@@ -4,9 +4,8 @@ import { createGlobalId } from "@apollosproject/server-core";
 import { StreamChat as StreamChatClient } from "stream-chat";
 import { get } from 'lodash';
 
-const { STREAM, FEATURE_FLAGS } = ApollosConfig;
+const { STREAM } = ApollosConfig;
 const { CHAT_SECRET, CHAT_API_KEY } = STREAM;
-const MODERATOR_GROUP_ID = get(FEATURE_FLAGS, 'LIVE_STREAM_CHAT.moderatorGroupId', -1);
 
 // Define singleton instance of StreamChatClient
 let chatClient;
@@ -35,14 +34,11 @@ export default class StreamChat extends RESTDataSource {
     return chatClient.createToken(streamUserId);
   };
 
-  currentUserIsGlobalModerator = async () => {
-    const { Auth } = this.context.dataSources;
+  currentUserIsLiveStreamModerator = async () => {
+    const { Flag } = this.context.dataSources;
+    const flagStatus = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT_MODERATOR');
 
-    if (await Auth.isInSecurityGroup(MODERATOR_GROUP_ID)) {
-      return true;
-    }
-
-    return false;
+    return flagStatus === 'LIVE';
   }
 
   addModerator = async ({ channelId, userId, channelType = 'livestream' }) => {


### PR DESCRIPTION
# Related Issue
- [**🏕 Make a chat moderator Security Group in Rock**](https://3.basecamp.com/3926363/buckets/17566548/todos/3098262058)
- [**🏕 [API] Create GROUP_CHAT Feature flag**](https://3.basecamp.com/3926363/buckets/17566548/todos/3115906311)

# Changes or Updates
- Defines a global moderator security group ID for livestream events
- Slight refactor of resolver for `AuthUser.streamChatRole`
  - Pushes logic out of core `resolver` into `data-source`
  - Makes methods more flexible, in anticipation of usage for Group Chat
- Add `GROUP_CHAT` feature flag

# Test Instructions
You can do the testing via graphql playground locally (http://localhost:4000/graphql)

### Step 1: Get `authorization` token

Copy the `token` value from the response of this query:

```graphql
mutation authenticate($identity: String!, $password: String!) {
  authenticate(identity: $identity, password: $password) {
    token
  }
}
```

... with variables:
```json
{
  "identity": "<email>",
  "password": "<password>"
}
```

First, use your Differential or "real" user account. They should be a `moderator`.
We'll repeat these steps with a non-moderator user next.

### Step 2: Validate resolver behavior

In a new query tab, set the **HTTP Headers** value as `{ "authorization": "<token>" }` using the value you copied from Step 1.
This will perform queries on behalf of that authenticated user.

<details>
<summary><b>( 🍰 Optional ) For bonus testing points...</b></summary>
... you can add logging to the API methods to list the channel's users and their roles after the operations.

1. Open `src/data/stream-chat/data-source.js`
2. Add this function near the top of of the file:
```javascript
async function log(channel) {
  const moderators = await channel.queryMembers({ is_moderator: true });
  const users = await channel.queryMembers({ is_moderator: false });

  console.log('\n•••••  👮‍♀️ Moderators  ••••••••••••••••••••••••••••••••••••••');
  moderators.members.forEach(({ user: { id, role, name, updated_at } }) => {
    console.log({ id, role, name, updated_at });
  });

  console.log('\n•••••  👤 Users  ••••••••••••••••••••••••••••••••••••••');
  users.members.forEach(({ user: { id, role, name, updated_at } }) => {
    console.log({ id, role, name, updated_at });
  });
}
```
3. Then invoke it in the `addModerator` and `removeModerator` methods (lines 68 and 76) by doing `log(channel)`.

<table>
<thead><th>Code</th><th>Output</th></thead>
<tr>
<td><img src="https://user-images.githubusercontent.com/1812955/96061780-106b8d80-0e62-11eb-94cb-5567ed06bf7c.jpg" /></td><td><img src="https://user-images.githubusercontent.com/1812955/96061784-12cde780-0e62-11eb-9671-cc8d88a79c5d.jpg"/></td></tr></table>

NOTE for some reason, I see some users listed under the `moderators` section that have `"user"` role.
Not 100% sure why that is. Focus on your user for the purposes of this PR.
</details>

Paste this query, which will request your users' role against an existing event chat channel:

```graphql
query {
  currentUser {
    id
    streamChatToken
    streamChatRole(id: "1e07e4f2e1b52807e43b2338c73d88ba")
    profile {
      firstName
      lastName
      photo {
        uri
      }
    }
  }
}
```

1. Verify you see your correct user details in the response (name, etc)
1. Verify your `streamChatRole` is `MODERATOR`
1. Repeat these instructions, but login as `yoda@jedi.order / yoda` or `anakin@jedi.order / anakin`.
1. Verify the `streamChatRole is `USER`