### PR TITLE
Updates Check In for Event Content Items

### DIFF
--- a/src/data/live-stream/data-source.js
+++ b/src/data/live-stream/data-source.js
@@ -241,9 +241,8 @@ export default class LiveStream extends matrixItemDataSource {
       })
     }
 
-    const contentItems = await byContentItems()
     const attributeMatrix = await this.byAttributeMatrixTemplate()
 
-    return [...contentItems, ...attributeMatrix].filter(i => !!i)
+    return attributeMatrix.filter(i => !!i)
   }
 }


### PR DESCRIPTION
There was an issue where the API was looking for a property on a null value.

This was caused by the _old_ way of handling Check In for Event Content Items. I've now updated this query to load in the new CheckInable method and it loads up just fine in the app, now.