### PR TITLE
Add liveStreamActions to live stream

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "printWidth": 90,
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "semi": true
+}

--- a/src/data/defined-value-list/data-source.js
+++ b/src/data/defined-value-list/data-source.js
@@ -1,12 +1,13 @@
-import RockApolloDataSource from '@apollosproject/rock-apollo-data-source'
-import { getIdentifierType } from '../utils'
+import RockApolloDataSource from '@apollosproject/rock-apollo-data-source';
+import { getIdentifierType } from '../utils';
 
 export default class DefinedValueList extends RockApolloDataSource {
-    resource = 'DefinedValues'
+  resource = 'DefinedValues';
+  expanded = true;
 
-    getByIdentifier = async (id) => {
-        const definedValues = await this.request().filter(`DefinedTypeId eq ${id}`).get()
+  getByIdentifier = async (id) => {
+    const definedValues = await this.request().filter(`DefinedTypeId eq ${id}`).get();
 
-        return { id, definedValues }
-    }
+    return { id, definedValues };
+  };
 }

--- a/src/data/event-content-item/resolver.js
+++ b/src/data/event-content-item/resolver.js
@@ -122,23 +122,6 @@ const resolver = {
           },
         };
       });
-
-      return Object.entries(filterScheduleDictionary).map(([name, schedules]) => {
-        return {
-          name,
-          instances: async () => {
-            const rockSchedules = await Schedule.getFromIds(schedules);
-            const times = await Promise.all(
-              rockSchedules.map((s) => Event.parseScheduleAsEvents(s))
-            );
-
-            return uniqBy(
-              flatten(times).sort((a, b) => moment(a.start).diff(b.start)),
-              'start'
-            );
-          },
-        };
-      });
     },
   },
 };

--- a/src/data/event-content-item/resolver.js
+++ b/src/data/event-content-item/resolver.js
@@ -14,12 +14,7 @@ const resolver = {
     ...sharingResolver,
     ...deprecatedResolvers,
     htmlContent: ({ content }) => sanitizeHtml(content),
-    sharing: (
-      root,
-      args,
-      { dataSources: { ContentItem } },
-      { parentType }
-    ) => ({
+    sharing: (root, args, { dataSources: { ContentItem } }, { parentType }) => ({
       url: ContentItem.generateShareUrl(root, parentType),
       title: 'Share via ...',
       message: ContentItem.generateShareMessage(root),
@@ -41,12 +36,10 @@ const resolver = {
       const matrixGuid = get(attributeValues, 'actions.value', '');
       const matrixItems = await MatrixItem.getItemsFromId(matrixGuid);
 
-      return matrixItems.map(
-        ({ attributeValues: matrixItemAttributeValues }) => ({
-          call: get(matrixItemAttributeValues, 'title.value', ''),
-          action: get(matrixItemAttributeValues, 'url.value', ''),
-        })
-      );
+      return matrixItems.map(({ attributeValues: matrixItemAttributeValues }) => ({
+        call: get(matrixItemAttributeValues, 'title.value', ''),
+        action: get(matrixItemAttributeValues, 'url.value', ''),
+      }));
     },
     label: async (
       { attributeValues },
@@ -60,25 +53,17 @@ const resolver = {
 
       // Get Schedules
       const schedules = await Schedule.getFromIds(
-        uniq(
-          matrixItems.map((m) =>
-            get(item, 'attributeValues.schedule.value', '')
-          )
-        )
+        uniq(matrixItems.map((m) => get(item, 'attributeValues.schedule.value', '')))
       );
 
       // Sort by start date asc, take the first
       const eventStart = first(
-        schedules.sort((a, b) =>
-          moment(a.effectiveStartDate).diff(b.effectiveStartDate)
-        )
+        schedules.sort((a, b) => moment(a.effectiveStartDate).diff(b.effectiveStartDate))
       );
 
       // Sort by end date desc, take the first
       const eventEnd = first(
-        schedules.sort((a, b) =>
-          moment(b.effectiveEndDate).diff(a.effectiveEndDate)
-        )
+        schedules.sort((a, b) => moment(b.effectiveEndDate).diff(a.effectiveEndDate))
       );
 
       return '';
@@ -121,43 +106,39 @@ const resolver = {
         }
       });
 
-      return Object.entries(filterScheduleDictionary).map(
-        ([name, schedules]) => {
-          return {
-            name,
-            instances: async () => {
-              const rockSchedules = await Schedule.getFromIds(schedules);
-              const times = await Promise.all(
-                rockSchedules.map((s) => Event.parseScheduleAsEvents(s))
-              );
+      return Object.entries(filterScheduleDictionary).map(([name, schedules]) => {
+        return {
+          name,
+          instances: async () => {
+            const rockSchedules = await Schedule.getFromIds(schedules);
+            const times = await Promise.all(
+              rockSchedules.map((s) => Event.parseScheduleAsEvents(s))
+            );
 
-              return uniqBy(
-                flatten(times).sort((a, b) => moment(a.start).diff(b.start)),
-                'start'
-              );
-            },
-          };
-        }
-      );
+            return uniqBy(
+              flatten(times).sort((a, b) => moment(a.start).diff(b.start)),
+              'start'
+            );
+          },
+        };
+      });
 
-      return Object.entries(filterScheduleDictionary).map(
-        ([name, schedules]) => {
-          return {
-            name,
-            instances: async () => {
-              const rockSchedules = await Schedule.getFromIds(schedules);
-              const times = await Promise.all(
-                rockSchedules.map((s) => Event.parseScheduleAsEvents(s))
-              );
+      return Object.entries(filterScheduleDictionary).map(([name, schedules]) => {
+        return {
+          name,
+          instances: async () => {
+            const rockSchedules = await Schedule.getFromIds(schedules);
+            const times = await Promise.all(
+              rockSchedules.map((s) => Event.parseScheduleAsEvents(s))
+            );
 
-              return uniqBy(
-                flatten(times).sort((a, b) => moment(a.start).diff(b.start)),
-                'start'
-              );
-            },
-          };
-        }
-      );
+            return uniqBy(
+              flatten(times).sort((a, b) => moment(a.start).diff(b.start)),
+              'start'
+            );
+          },
+        };
+      });
     },
   },
 };

--- a/src/data/event-content-item/resolver.js
+++ b/src/data/event-content-item/resolver.js
@@ -48,43 +48,6 @@ const resolver = {
         })
       );
     },
-    liveStreamActions: async ({ attributeValues }, args, { dataSources }) => {
-      // Get Matrix Items
-      const { MatrixItem } = dataSources;
-      const liveStreamActionsMatrixGuid = get(
-        attributeValues,
-        'liveStreamActions.value',
-        ''
-      );
-      const liveStreamActionsItems = await MatrixItem.getItemsFromId(
-        liveStreamActionsMatrixGuid
-      );
-
-      const defaultLiveStreamActions = [
-        { call: 'Get Connected', action: 'https://christfellowship.church/' },
-        { call: 'I Have Decided', action: 'https://christfellowship.church/' },
-        { call: 'Give Online', action: 'https://christfellowship.church/' },
-      ];
-
-      const liveStreamActionsItemsMapped = liveStreamActionsItems.map(
-        ({ attributeValues: liveStreamActionsItemsAttributeValues }) => ({
-          call: get(liveStreamActionsItemsAttributeValues, 'title.value', ''),
-          action: get(liveStreamActionsItemsAttributeValues, 'url.value', ''),
-          duration: get(
-            liveStreamActionsItemsAttributeValues,
-            'duration.value',
-            ''
-          ),
-          startTime: get(
-            liveStreamActionsItemsAttributeValues,
-            'startTime.value',
-            ''
-          ),
-        })
-      );
-
-      return defaultLiveStreamActions.concat(liveStreamActionsItemsMapped);
-    },
     label: async (
       { attributeValues },
       args,

--- a/src/data/event-content-item/resolver.js
+++ b/src/data/event-content-item/resolver.js
@@ -1,21 +1,12 @@
-import {
-  ContentItem as coreContentItem,
-} from '@apollosproject/data-connector-rock'
-import {
-  get,
-  flatten,
-  uniq,
-  uniqBy,
-  first,
-  filter
-} from 'lodash'
-import moment from 'moment'
-import momentTz from 'moment-timezone'
+import { ContentItem as coreContentItem } from '@apollosproject/data-connector-rock';
+import { get, flatten, uniq, uniqBy, first, filter } from 'lodash';
+import moment from 'moment';
+import momentTz from 'moment-timezone';
 
-import { parseRockKeyValuePairs } from '../utils'
-import sanitizeHtml from '../sanitize-html'
-import { sharingResolver } from '../content-item/resolver'
-import deprecatedResolvers from './deprecated-resolvers'
+import { parseRockKeyValuePairs } from '../utils';
+import sanitizeHtml from '../sanitize-html';
+import { sharingResolver } from '../content-item/resolver';
+import deprecatedResolvers from './deprecated-resolvers';
 
 const resolver = {
   EventContentItem: {
@@ -119,32 +110,35 @@ const resolver = {
         const schedule = get(item, 'attributeValues.schedule.value', '');
         const filters = get(item, 'attributeValues.filters.value', '');
 
-        if (schedule && schedule !== "" && filters && filters !== "") {
-          filters.split(',').forEach(filter => {
+        if (schedule && schedule !== '' && filters && filters !== '') {
+          filters.split(',').forEach((filter) => {
             if (filterScheduleDictionary[filter]) {
-              filterScheduleDictionary[filter].push(schedule)
+              filterScheduleDictionary[filter].push(schedule);
             } else {
-              filterScheduleDictionary[filter] = [schedule]
+              filterScheduleDictionary[filter] = [schedule];
             }
-          })
+          });
         }
-      })
-
-      return Object.entries(filterScheduleDictionary).map(([name, schedules]) => {
-        return {
-          name,
-          instances: async () => {
-            const rockSchedules = await Schedule.getFromIds(schedules)
-            const times = await Promise.all(rockSchedules.map(s => Event.parseScheduleAsEvents(s)))
-
-            return uniqBy(
-              flatten(times)
-                .sort((a, b) => moment(a.start).diff(b.start)),
-              'start'
-            )
-          }
-        });
       });
+
+      return Object.entries(filterScheduleDictionary).map(
+        ([name, schedules]) => {
+          return {
+            name,
+            instances: async () => {
+              const rockSchedules = await Schedule.getFromIds(schedules);
+              const times = await Promise.all(
+                rockSchedules.map((s) => Event.parseScheduleAsEvents(s))
+              );
+
+              return uniqBy(
+                flatten(times).sort((a, b) => moment(a.start).diff(b.start)),
+                'start'
+              );
+            },
+          };
+        }
+      );
 
       return Object.entries(filterScheduleDictionary).map(
         ([name, schedules]) => {

--- a/src/data/event-content-item/schema.js
+++ b/src/data/event-content-item/schema.js
@@ -49,7 +49,6 @@ export default gql`
     @deprecated(
       reason: "Updating to use FeatureAction to better adhere to navigation standards. Please use 'actions' instead."
     )
-    liveStreamActions: [CallToAction]
     openLinksInNewTab: Boolean
     @deprecated(reason: "Label will now be explicitly defined on the API")
     hideLabel: Boolean

--- a/src/data/event-content-item/schema.js
+++ b/src/data/event-content-item/schema.js
@@ -1,4 +1,4 @@
-import gql from 'graphql-tag'
+import gql from 'graphql-tag';
 
 export default gql`
   ## Describes where and when a collection of events is happening
@@ -8,7 +8,7 @@ export default gql`
   }
 
   extend type Query {
-    getEventContentByTitle(title:String!): EventContentItem
+    getEventContentByTitle(title: String!): EventContentItem
   }
 
   type EventContentItem implements ContentItem & Node {
@@ -31,29 +31,39 @@ export default gql`
     parentChannel: ContentChannel
     theme: Theme
 
-    nextOccurrence: String 
-      @deprecated(reason: "Previously used to create a label on the client. Please use 'label' instead")
-    startDate: String 
-      @deprecated(reason: "Previously used to create a label on the client. Please use 'label' instead")
-    endDate: String 
-      @deprecated(reason: "Previously used to create a label on the client. Please use 'label' instead")
+    nextOccurrence: String
+    @deprecated(
+      reason: "Previously used to create a label on the client. Please use 'label' instead"
+    )
+    startDate: String
+    @deprecated(
+      reason: "Previously used to create a label on the client. Please use 'label' instead"
+    )
+    endDate: String
+    @deprecated(
+      reason: "Previously used to create a label on the client. Please use 'label' instead"
+    )
 
     tags: [String]
-    callsToAction: [CallToAction] 
-      @deprecated(reason: "Updating to use FeatureAction to better adhere to navigation standards. Please use 'actions' instead.")
-    openLinksInNewTab: Boolean 
-      @deprecated(reason: "Label will now be explicitly defined on the API")
-    hideLabel: Boolean 
-      @deprecated(reason: "Label will now be explicitly defined on the API")
-    events: [Event] 
-      @deprecated(reason: "We have updated the organization of the events schema. Please use 'eventGroupings' instead.")
+    callsToAction: [CallToAction]
+    @deprecated(
+      reason: "Updating to use FeatureAction to better adhere to navigation standards. Please use 'actions' instead."
+    )
+    liveStreamActions: [CallToAction]
+    openLinksInNewTab: Boolean
+    @deprecated(reason: "Label will now be explicitly defined on the API")
+    hideLabel: Boolean
+    @deprecated(reason: "Label will now be explicitly defined on the API")
+    events: [Event]
+    @deprecated(
+      reason: "We have updated the organization of the events schema. Please use 'eventGroupings' instead."
+    )
 
     # This label is an additional
     label: String
     eventGroupings: [EventGrouping]
   }
-`
-
+`;
 
 // sharing: SharableContentItem
 //     isLiked: Boolean @cacheControl(maxAge: 0)

--- a/src/data/features/schema.js
+++ b/src/data/features/schema.js
@@ -1,57 +1,66 @@
-import { featuresSchema } from '@apollosproject/data-schema'
-import gql from 'graphql-tag'
+import { featuresSchema } from '@apollosproject/data-schema';
+import gql from 'graphql-tag';
 
 export default gql`
-    ${featuresSchema}
+  ${featuresSchema}
 
-    extend enum ACTION_FEATURE_ACTION {
-        VIEW_CHILDREN
-        READ_GLOBAL_CONTENT
-        READ_PRAYER
-        READ_GROUP
-    }
+  extend enum ACTION_FEATURE_ACTION {
+    VIEW_CHILDREN
+    READ_GLOBAL_CONTENT
+    READ_PRAYER
+    READ_GROUP
+  }
 
-    extend type HorizontalCardListFeature {
-        primaryAction: FeatureAction
-    }
+  extend type HorizontalCardListFeature {
+    primaryAction: FeatureAction
+  }
 
-    type ActionBarFeatureAction {
-        relatedNode: Node
-        action: ACTION_FEATURE_ACTION
-        title: String
+  type ActionBarFeatureAction {
+    relatedNode: Node
+    action: ACTION_FEATURE_ACTION
+    title: String
 
-        icon: String
-        theme: Theme
-    }
+    icon: String
+    theme: Theme
+  }
 
-    type ActionBarFeature implements Feature & Node {
-        id: ID!
-        order: Int
-    
-        actions: [ActionBarFeatureAction]
-    }
+  type ActionBarFeature implements Feature & Node {
+    id: ID!
+    order: Int
 
-    type AvatarListFeature implements Feature & Node {
-        id: ID!
-        order: Int
-    
-        people: [Person]
-        isCard: Boolean
-        primaryAction: ActionBarFeatureAction
-    }
+    actions: [ActionBarFeatureAction]
+  }
 
-    type LiveStreamListFeature implements Feature & Node {
-        id: ID!
-        order: Int
-        title: String
-        subtitle: String
-        liveStreams: [LiveStream]
-    }
-    
-    extend type Query {
-        connectFeedFeatures: [Feature] @cacheControl(maxAge: 0)
-        eventsFeedFeatures: [Feature] @cacheControl(maxAge: 0)
-        giveFeedFeatures: [Feature] @cacheControl(maxAge: 0)
-        userHeaderFeatures: [Feature] @cacheControl(maxAge: 0)
-    }
-`
+  type LiveStreamAction {
+    relatedNode: Node
+    action: ACTION_FEATURE_ACTION
+    title: String
+
+    start: Int
+    duration: Int
+  }
+
+  type AvatarListFeature implements Feature & Node {
+    id: ID!
+    order: Int
+
+    people: [Person]
+    isCard: Boolean
+    primaryAction: ActionBarFeatureAction
+  }
+
+  type LiveStreamListFeature implements Feature & Node {
+    id: ID!
+    order: Int
+    title: String
+    subtitle: String
+    liveStreams: [LiveStream]
+  }
+
+  extend type Query {
+    connectFeedFeatures: [Feature] @cacheControl(maxAge: 0)
+    eventsFeedFeatures: [Feature] @cacheControl(maxAge: 0)
+    giveFeedFeatures: [Feature] @cacheControl(maxAge: 0)
+    userHeaderFeatures: [Feature] @cacheControl(maxAge: 0)
+  }
+`;

--- a/src/data/features/schema.js
+++ b/src/data/features/schema.js
@@ -36,8 +36,9 @@ export default gql`
     action: ACTION_FEATURE_ACTION
     title: String
 
-    start: Int
     duration: Int
+    image: String
+    start: Int
   }
 
   type AvatarListFeature implements Feature & Node {

--- a/src/data/live-stream/resolver.js
+++ b/src/data/live-stream/resolver.js
@@ -45,7 +45,7 @@ const resolver = {
           action: 'OPEN_URL',
           relatedNode: {
             __typename: 'Url',
-            url: 'https://christfellowship.church/',
+            url: 'https://rock.christfellowship.church/connect',
           },
         },
         {
@@ -53,7 +53,7 @@ const resolver = {
           action: 'OPEN_URL',
           relatedNode: {
             __typename: 'Url',
-            url: 'https://christfellowship.church/',
+            url: 'https://rock.christfellowship.church/decision',
           },
         },
         {
@@ -61,7 +61,7 @@ const resolver = {
           action: 'OPEN_URL',
           relatedNode: {
             __typename: 'Url',
-            url: 'https://christfellowship.church/',
+            url: 'https://pushpay.com/g/christfellowship',
           },
         },
       ];

--- a/src/data/live-stream/resolver.js
+++ b/src/data/live-stream/resolver.js
@@ -41,7 +41,7 @@ const resolver = {
 
       const defaultLiveStreamActions = [
         {
-          call: 'Get Connected',
+          title: 'Get Connected',
           action: 'OPEN_URL',
           relatedNode: {
             __typename: 'Url',
@@ -49,7 +49,7 @@ const resolver = {
           },
         },
         {
-          call: 'I Have Decided',
+          title: 'I Have Decided',
           action: 'OPEN_URL',
           relatedNode: {
             __typename: 'Url',
@@ -57,7 +57,7 @@ const resolver = {
           },
         },
         {
-          call: 'Give Online',
+          title: 'Give Online',
           action: 'OPEN_URL',
           relatedNode: {
             __typename: 'Url',

--- a/src/data/live-stream/resolver.js
+++ b/src/data/live-stream/resolver.js
@@ -1,7 +1,10 @@
 import { createGlobalId, resolverMerge } from '@apollosproject/server-core';
 import * as coreLiveStream from '@apollosproject/data-connector-church-online';
+import { Utils } from '@apollosproject/data-connector-rock';
 import { get } from 'lodash';
 import moment from 'moment';
+
+const { createImageUrlFromGuid } = Utils;
 
 const resolver = {
   LiveNode: {
@@ -72,18 +75,27 @@ const resolver = {
           duration: get(
             liveStreamActionsItemsAttributeValues,
             'duration.value',
-            ''
+            null
           ),
+          image: get(liveStreamActionsItemsAttributeValues, 'image.value', null)
+            ? createImageUrlFromGuid(
+                liveStreamActionsItemsAttributeValues.image.value
+              )
+            : null,
           relatedNode: {
             __typename: 'Url',
-            url: get(liveStreamActionsItemsAttributeValues, 'url.value', ''),
+            url: get(liveStreamActionsItemsAttributeValues, 'url.value', null),
           },
           start: get(
             liveStreamActionsItemsAttributeValues,
             'startTime.value',
-            ''
+            null
           ),
-          title: get(liveStreamActionsItemsAttributeValues, 'title.value', ''),
+          title: get(
+            liveStreamActionsItemsAttributeValues,
+            'title.value',
+            null
+          ),
         })
       );
 

--- a/src/data/live-stream/resolver.js
+++ b/src/data/live-stream/resolver.js
@@ -29,9 +29,7 @@ const resolver = {
       return null;
     },
     actions: async ({ id, guid }, args, { dataSources }) => {
-      const unresolvedNode = await dataSources.LiveStream.getRelatedNodeFromId(
-        id
-      );
+      const unresolvedNode = await dataSources.LiveStream.getRelatedNodeFromId(id);
       // Get Matrix Items
       const liveStreamActionsMatrixGuid = get(
         unresolvedNode,
@@ -42,64 +40,43 @@ const resolver = {
         liveStreamActionsMatrixGuid
       );
 
-      const defaultLiveStreamActions = [
-        {
-          title: 'Get Connected',
+      const liveStreamDefaultActionItems = await dataSources.DefinedValueList.getByIdentifier(
+        367
+      );
+
+      const liveStreamDefaultActionItemsMapped = liveStreamDefaultActionItems.definedValues.map(
+        ({ attributeValues: defaultLiveStreamActionsItemsAttributeValues }) => ({
           action: 'OPEN_URL',
+          image: get(defaultLiveStreamActionsItemsAttributeValues, 'image.value', null)
+            ? createImageUrlFromGuid(
+                defaultLiveStreamActionsItemsAttributeValues.image.value
+              )
+            : null,
           relatedNode: {
             __typename: 'Url',
-            url: 'https://rock.christfellowship.church/connect',
+            url: get(defaultLiveStreamActionsItemsAttributeValues, 'url.value', null),
           },
-        },
-        {
-          title: 'I Have Decided',
-          action: 'OPEN_URL',
-          relatedNode: {
-            __typename: 'Url',
-            url: 'https://rock.christfellowship.church/decision',
-          },
-        },
-        {
-          title: 'Give Online',
-          action: 'OPEN_URL',
-          relatedNode: {
-            __typename: 'Url',
-            url: 'https://pushpay.com/g/christfellowship',
-          },
-        },
-      ];
+          title: get(defaultLiveStreamActionsItemsAttributeValues, 'title.value', null),
+        })
+      );
 
       const liveStreamActionsItemsMapped = liveStreamActionsItems.map(
         ({ attributeValues: liveStreamActionsItemsAttributeValues }) => ({
           action: 'OPEN_URL',
-          duration: get(
-            liveStreamActionsItemsAttributeValues,
-            'duration.value',
-            null
-          ),
+          duration: get(liveStreamActionsItemsAttributeValues, 'duration.value', null),
           image: get(liveStreamActionsItemsAttributeValues, 'image.value', null)
-            ? createImageUrlFromGuid(
-                liveStreamActionsItemsAttributeValues.image.value
-              )
+            ? createImageUrlFromGuid(liveStreamActionsItemsAttributeValues.image.value)
             : null,
           relatedNode: {
             __typename: 'Url',
             url: get(liveStreamActionsItemsAttributeValues, 'url.value', null),
           },
-          start: get(
-            liveStreamActionsItemsAttributeValues,
-            'startTime.value',
-            null
-          ),
-          title: get(
-            liveStreamActionsItemsAttributeValues,
-            'title.value',
-            null
-          ),
+          start: get(liveStreamActionsItemsAttributeValues, 'startTime.value', null),
+          title: get(liveStreamActionsItemsAttributeValues, 'title.value', null),
         })
       );
 
-      return defaultLiveStreamActions.concat(liveStreamActionsItemsMapped);
+      return liveStreamDefaultActionItemsMapped.concat(liveStreamActionsItemsMapped);
     },
     contentItem: ({ contentChannelItemId }, _, { models, dataSources }) => {
       if (contentChannelItemId) {
@@ -146,9 +123,7 @@ const resolver = {
       _,
       { dataSources: { Flag } }
     ) => {
-      const featureFlag = await Flag.currentUserCanUseFeature(
-        'LIVE_STREAM_CHAT'
-      );
+      const featureFlag = await Flag.currentUserCanUseFeature('LIVE_STREAM_CHAT');
       if (featureFlag !== 'LIVE') return null;
 
       return { id: JSON.stringify({ id, eventStartTime, eventEndTime }) };

--- a/src/data/live-stream/schema.js
+++ b/src/data/live-stream/schema.js
@@ -4,53 +4,56 @@ import gql from 'graphql-tag';
  * Copies the LiveStream schema from @apollos/data-schema-1.5.0
  */
 export default gql`
-    interface LiveNode {
-        liveStream: LiveStream
-    }
+  interface LiveNode {
+    liveStream: LiveStream
+  }
 
-    extend type EventContentItem implements LiveNode {
-        liveStream: LiveStream
-    }
+  extend type EventContentItem implements LiveNode {
+    liveStream: LiveStream
+  }
 
-    type LiveStream implements Node {
-        id: ID!
-        isLive: Boolean @cacheControl(maxAge: 10)
-        eventStartTime: String
-        eventEndTime: String
-        media: VideoMedia
-        webViewUrl: String
-        contentItem: ContentItem @cacheControl(maxAge: 10) 
-            @deprecated(reason: "LiveStreams are not limited to ContentItems. Please use 'relatedNode' instead.")
+  type LiveStream implements Node {
+    id: ID!
+    isLive: Boolean @cacheControl(maxAge: 10)
+    eventStartTime: String
+    eventEndTime: String
+    media: VideoMedia
+    webViewUrl: String
+    contentItem: ContentItem
+    @cacheControl(maxAge: 10)
+    @deprecated(
+      reason: "LiveStreams are not limited to ContentItems. Please use 'relatedNode' instead."
+    )
 
-        relatedNode: Node
+    relatedNode: Node
 
-        chatChannelId: String
-            @deprecated(reason: "Use 'streamChatChannel' instead")
-    }
+    chatChannelId: String @deprecated(reason: "Use 'streamChatChannel' instead")
+    actions: [LiveStreamAction]
+  }
 
-    extend type WeekendContentItem {
-        liveStream: LiveStream
-    }
-  
-    type FloatLeftLiveStream {
-        start: String
-        isLive: Boolean
-        coverImage: ImageMedia
-        media: VideoMedia
-        title: String
-    }
+  extend type WeekendContentItem {
+    liveStream: LiveStream
+  }
 
-    extend type Query {
-        liveStream: LiveStream
-            @deprecated(reason: "Use liveStreams, there may be multiple.")
-        liveStreams: [LiveStream] @cacheControl(maxAge: 10)
+  type FloatLeftLiveStream {
+    start: String
+    isLive: Boolean
+    coverImage: ImageMedia
+    media: VideoMedia
+    title: String
+  }
 
-        floatLeftLiveStream: LiveStream
-        floatLeftEmptyLiveStream: LiveStream
-    }
+  extend type Query {
+    liveStream: LiveStream
+    @deprecated(reason: "Use liveStreams, there may be multiple.")
+    liveStreams: [LiveStream] @cacheControl(maxAge: 10)
 
-    extend enum InteractionAction {
-        LIVESTREAM_JOINED
-        LIVESTREAM_CLOSED
-    }
+    floatLeftLiveStream: LiveStream
+    floatLeftEmptyLiveStream: LiveStream
+  }
+
+  extend enum InteractionAction {
+    LIVESTREAM_JOINED
+    LIVESTREAM_CLOSED
+  }
 `;

--- a/src/data/website-content-item/schema.js
+++ b/src/data/website-content-item/schema.js
@@ -1,39 +1,41 @@
-import { contentItemSchema } from '@apollosproject/data-schema'
-import { gql } from 'apollo-server'
+import { contentItemSchema } from '@apollosproject/data-schema';
+import { gql } from 'apollo-server';
 
 export default gql`
-    type CallToAction {
-        call: String
-        action: String
-    }
+  type CallToAction {
+    call: String
+    action: String
+    duration: Int
+    startTime: Int
+  }
 
-    type WebsiteBlockItem implements ContentItem & Node {
-        id: ID!
-        title(hyphenated: Boolean): String
-        coverImage: ImageMedia
-        images: [ImageMedia]
-        videos: [VideoMedia]
-        audios: [AudioMedia]
-        htmlContent: String
-        summary: String
-        childContentItemsConnection(
-            first: Int
-            after: String
-        ): ContentItemsConnection
-        siblingContentItemsConnection(
-            first: Int
-            after: String
-        ): ContentItemsConnection
-        parentChannel: ContentChannel
-        theme: Theme
+  type WebsiteBlockItem implements ContentItem & Node {
+    id: ID!
+    title(hyphenated: Boolean): String
+    coverImage: ImageMedia
+    images: [ImageMedia]
+    videos: [VideoMedia]
+    audios: [AudioMedia]
+    htmlContent: String
+    summary: String
+    childContentItemsConnection(
+      first: Int
+      after: String
+    ): ContentItemsConnection
+    siblingContentItemsConnection(
+      first: Int
+      after: String
+    ): ContentItemsConnection
+    parentChannel: ContentChannel
+    theme: Theme
 
-        contentLayout: String
-        imageAlt: String
-        imageRatio: String
-        callToAction: CallToAction
-        secondaryCallToAction: CallToAction
-        subtitle: String
+    contentLayout: String
+    imageAlt: String
+    imageRatio: String
+    callToAction: CallToAction
+    secondaryCallToAction: CallToAction
+    subtitle: String
 
-        openLinksInNewTab: Boolean
-    }
-`
+    openLinksInNewTab: Boolean
+  }
+`;


### PR DESCRIPTION
This PR adds actions to live streams. You need an active live stream and a live stream action on your event in Rock to test. I quickly added one and then removed it to test earlier. This is not altering an existing logic just adding actions to the live stream resolver.
![image](https://user-images.githubusercontent.com/2528817/98010572-78a3f400-1dbc-11eb-9fa7-2579d3801252.png)

Here is what a potential query might look like.
![image](https://user-images.githubusercontent.com/2528817/98010474-5b6f2580-1dbc-11eb-9b19-5aa0b893ca53.png)
