### PR TITLE
For all versions less than 5.4.0, resolve all EventContentItem to Inf…

### DIFF
--- a/src/data/content-item/data-source.js
+++ b/src/data/content-item/data-source.js
@@ -89,6 +89,7 @@ export default class ContentItem extends coreContentItem.dataSource {
       id,
       attributeValues,
       attributes,
+      contentChannelTypeId
     } = props
     const versionParse = split(clientVersion, '.').join('')
 
@@ -102,6 +103,20 @@ export default class ContentItem extends coreContentItem.dataSource {
     if (parseInt(versionParse) > 520) {
       if (get(attributeValues, 'scriptures', '') !== "") {
         return "DevotionalContentItem"
+      }
+    }
+
+    /**
+     * Versions of the app that are lower than 5.4.0 have a visual bug where they
+     * don't ever show dates/times on EventContentItems.
+     * 
+     * We have an error in logic where the `hideLabel` boolean flag is not respected,
+     * so we need to just resolve all `EventContentItem` types to `InformationalContentItem`
+     * to avoid the visual issue.
+     */
+    if (parseInt(versionParse) < 540) {
+      if (get(ROCK_MAPPINGS, 'CONTENT_ITEM.EventContentItem.ContentChannelTypeId', []).includes(contentChannelTypeId)) {
+        return 'InformationalContentItem'
       }
     }
 

--- a/src/data/informational-content-item/resolver.js
+++ b/src/data/informational-content-item/resolver.js
@@ -14,11 +14,25 @@ const resolver = {
   InformationalContentItem: {
     ...coreContentItem.resolver.ContentItem,
     redirectUrl: ({ attributeValues }) => get(attributeValues, 'redirectUrl.value', ''),
-    callsToAction: ({ attributeValues }, args, { dataSources }) =>
-      parseRockKeyValuePairs(
+    callsToAction: async ({ attributeValues }, args, { dataSources }) => {
+      // Deprecated Content Channel Type
+      const ctaValuePairs = parseRockKeyValuePairs(
         get(attributeValues, 'callsToAction.value', ''),
         'call',
-        'action'),
+        'action')
+
+      if (ctaValuePairs.length) return ctaValuePairs
+
+      // Get Matrix Items
+      const { MatrixItem } = dataSources
+      const matrixGuid = get(attributeValues, 'actions.value', '')
+      const matrixItems = await MatrixItem.getItemsFromId(matrixGuid)
+
+      return matrixItems.map(({ attributeValues: matrixItemAttributeValues }) => ({
+        call: get(matrixItemAttributeValues, 'title.value', ''),
+        action: get(matrixItemAttributeValues, 'url.value', ''),
+      }))
+    },
     htmlContent: ({ content }) => sanitizeHtml(content),
     sharing: (root, args, { dataSources: { ContentItem } }, { parentType }) => ({
       url: ContentItem.generateShareUrl(root, parentType),


### PR DESCRIPTION
Versions of the app that are lower than 5.4.0 have a visual bug where they don't ever show dates/times on EventContentItems.

We have an error in logic where the `hideLabel` boolean flag is not respected, so we need to just resolve all `EventContentItem` types to `InformationalContentItem` to avoid the visual issue.