### PR TITLE
[GroupItem] Fix resolution of GroupItem.dateTime when missing schedule

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -379,6 +379,10 @@ export default class GroupItem extends baseGroup.dataSource {
         schedule.id
       );
 
+      if (!occurrences || !occurrences.length) {
+        return { start: null, end: null };
+      }
+
       const nextOccurrence = head(occurrences);
       return { start: nextOccurrence.start, end: nextOccurrence.end };
     } else if (weeklyDayOfWeek !== null && weeklyTimeOfDay) {

--- a/src/data/schedule/data-source.js
+++ b/src/data/schedule/data-source.js
@@ -35,7 +35,7 @@ export default class Schedule extends RockApolloDataSource {
         if (result != null) {
           Cache.set({
             key: cachedKey,
-            data: attributeMatrix,
+            data: result,
             expiresIn: 60 * 5 // 5 minute
           });
         }
@@ -188,9 +188,9 @@ export default class Schedule extends RockApolloDataSource {
       })
 
     /** TL;DR: parseiCalendar filters by the _day_ of the event, not the time
-     *  
+     *
      *  The first event that is returned is the closest event.
-     *  If the event is today, but already past the time 
+     *  If the event is today, but already past the time
      *  (ie: event starts at 9am and right now is 10am), the event
      *  will still return today's instance.
      */
@@ -246,7 +246,7 @@ export default class Schedule extends RockApolloDataSource {
     const duration = get(args, 'duration')
     /** Before parsing the iCal object, we need to find and replace the start and end data/time
      *  with one that specifies the current timezone of the event
-     * 
+     *
      *  Rock returns a DTSTART/DTEND in the following format: DTSTART:20200419T171500
      *  which is ambiguous to the time zone, so node-ical will pick the local one
      *  node-ical wants time zone specified in the following manner: DTSTART;TZID=America/New_York:20200419T171500
@@ -304,7 +304,7 @@ export default class Schedule extends RockApolloDataSource {
         /** For repeated events, we only want the very next occurence
          *  based on today's date, so we use the after method of rrule
          *  to get the next occurrence based on the today's date
-         *  
+         *
          *  In order to insure that an event will remain visible on the
          *  platform while the event is happening, we offset the time of
          *  'now' by the duration of the event


### PR DESCRIPTION
Fixes a bug currently happening with the 3x test groups that I'm in (Brandi's Tech, CFDP Testing, Brandi's Large Revelation) where due to some unknown reason, the group's `schedule` cannot be found so `occurrences` cannot be determined.
They're assumed to be there, so resolving `dateTime` fails and throws a 500 error.

The UI/client effect of this is that the **web** groups list page and individual pages won't load, and individual group detail views on **app** break as well.

Also fixes a copy/paste issue with the caching mechanism for `Schedules` so the result gets stored properly.

|Before|After|
|---|---|
|![image](https://user-images.githubusercontent.com/1812955/98020897-9a5ba600-1dd1-11eb-9aca-79923c8ed8c9.png)|![image (7)](https://user-images.githubusercontent.com/1812955/98021017-c1b27300-1dd1-11eb-9630-79aa3c3df9d4.png)|

# Test Instructions
**Query**

Make sure to have an authorization HTTP header, then run this query and make sure it resolves properly:

```graphql
query getCurrentUserGroups {
  currentUser {
    id
    profile {
      id
      groups(input: {excludeTypes: [DreamTeam]}) {
        ... on Group {
          id
          dateTime {
            start
            end
            __typename
          }
          __typename
        }
        title
        coverImage {
          sources {
            uri
            __typename
          }
          __typename
        }
        __typename
      }
      __typename
    }
    __typename
  }
}

```