### PR TITLE
Add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,44 @@
+## DESCRIPTION
+
+### 1. What does this PR do, or why is it needed?
+
+### 2. What design trade-offs/decisions were made?
+
+### 3. How do I test this PR?
+
+### 4. What automated tests did you write?
+
+## SCREENSHOTS/GIFS
+
+| iOS | Android | Web |
+| --- | ------- | --- |
+|     |         |     |
+
+## TODO:
+
+- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
+- [ ] Closes [tag-issues-here]
+- [ ] No new warnings in tests, storybook, or apps
+- [ ] Assign relevant reviewers
+- [ ] Upload GIF(s) of iOS, Android, Web
+- [ ] Get one peer approval before merging
+
+## REVIEW:
+
+**Manual QA**
+
+- [ ] QA branch on iOS and ensure it looks/behaves as expected
+- [ ] QA branch on Android and ensure it looks/behaves as expected
+- [ ] QA branch on Web and ensure it looks/behaves as expected
+
+**Code Review**
+
+- [ ] Read through the "Files changed" tab _very carefully_
+- [ ] Edge cases: what assumptions are made about input?
+- [ ] What kind of tests could be written?
+- [ ] How might we make this easier for someone else to understand?
+- [ ] Could the code be simpler?
+- [ ] Will the code be easy to modify in the future?
+- [ ] What's one part of these changes that makes you excited to merge it?
+
+> The purpose of PR Review is to _improve the quality of the software._


### PR DESCRIPTION
What does this PR do, or why is it needed?

Adds a PR template to standardize pull request information. This will hopefully improve speed and quality of reviews and help us ship code more confidently. Please feel free tweak, commit, or suggest changes.