### PR TITLE
Content prep client 5.4.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -326,16 +326,7 @@ FEATURE_FEEDS:
           arguments:
             contentChannelId: 76
     - type: ActionBar
-      actions:
-        - action: OPEN_URL
-          title: "Give Now"
-          icon: "envelope-open-dollar"
-          theme:
-            colors:
-              primary: "#1ec27f"
-          relatedNode:
-            __typename: Url
-            url: "https://pushpay.com/g/christfellowship"
+      actions: []
   HOME_HEADER:
     - algorithms: [ALL_LIVE_CONTENT]
       type: LiveContentList

--- a/config.yml
+++ b/config.yml
@@ -298,7 +298,7 @@ FEATURE_FEEDS:
               primary: "#1ec27f"
           relatedNode:
             __typename: Url
-            url: "https://pushpay.com/g/christfellowship"
+            url: "https://cf.church/pushpay?feed=connect"
     - type: HorizontalCardList
       algorithms: [MY_GROUPS]
       title: "My Groups"

--- a/src/data/features/data-source.js
+++ b/src/data/features/data-source.js
@@ -440,7 +440,7 @@ export default class Feature extends coreFeatures.dataSource {
             },
             relatedNode: {
                 __typename: 'Url',
-                url: "https://cf.church/pushpay"
+                url: "https://cf.church/pushpay?feed=give"
             }
         }
         const payPalConfig = {
@@ -454,7 +454,7 @@ export default class Feature extends coreFeatures.dataSource {
             },
             relatedNode: {
                 __typename: 'Url',
-                url: "http://cf.church/paypal"
+                url: "http://cf.church/paypal?feed=give"
             }
         }
         const cashAppConfig = {
@@ -468,7 +468,7 @@ export default class Feature extends coreFeatures.dataSource {
             },
             relatedNode: {
                 __typename: 'Url',
-                url: "http://cf.church/cash-app"
+                url: "http://cf.church/cash-app?feed=give"
             }
         }
         const venmoConfig = {
@@ -482,7 +482,7 @@ export default class Feature extends coreFeatures.dataSource {
             },
             relatedNode: {
                 __typename: 'Url',
-                url: "http://cf.church/venmo"
+                url: "http://cf.church/venmo?feed=give"
             }
         }
 

--- a/src/data/features/data-source.js
+++ b/src/data/features/data-source.js
@@ -426,7 +426,78 @@ export default class Feature extends coreFeatures.dataSource {
     }
 
     getGiveFeedFeatures() {
-        return this.getFeedFeatures(get(ApollosConfig, 'FEATURE_FEEDS.GIVE_TAB', []));
+        const { clientVersion } = this.context;
+        const versionParse = split(clientVersion, '.').join('')
+        const config = get(ApollosConfig, 'FEATURE_FEEDS.GIVE_TAB', [])
+        const pushPayConfig = {
+            action: 'OPEN_URL',
+            title: "PushPay",
+            icon: "push-pay",
+            theme: {
+                colors: {
+                    primary: "#d52158"
+                }
+            },
+            relatedNode: {
+                __typename: 'Url',
+                url: "https://cf.church/pushpay"
+            }
+        }
+        const payPalConfig = {
+            action: 'OPEN_URL',
+            title: "PayPal",
+            icon: "pay-pal",
+            theme: {
+                colors: {
+                    primary: "#179bd7"
+                }
+            },
+            relatedNode: {
+                __typename: 'Url',
+                url: "http://cf.church/paypal"
+            }
+        }
+        const cashAppConfig = {
+            action: 'OPEN_URL',
+            title: "CashApp",
+            icon: "cash-app",
+            theme: {
+                colors: {
+                    primary: "#1ec27f"
+                }
+            },
+            relatedNode: {
+                __typename: 'Url',
+                url: "http://cf.church/cash-app"
+            }
+        }
+        const venmoConfig = {
+            action: 'OPEN_URL',
+            title: "Venmo",
+            icon: "venmo",
+            theme: {
+                colors: {
+                    primary: "#00aeef"
+                }
+            },
+            relatedNode: {
+                __typename: 'Url',
+                url: "http://cf.church/venmo"
+            }
+        }
+
+        const actionIndex = config.findIndex(item => item.type === 'ActionBar')
+
+        if (parseInt(versionParse) >= 540) {
+            config[actionIndex].actions = [pushPayConfig, payPalConfig, cashAppConfig, venmoConfig]
+        } else {
+            pushPayConfig.icon = "envelope-open-dollar"
+            config[actionIndex].actions = [pushPayConfig]
+        }
+
+        console.log({config: config[1].actions})
+
+        return this.getFeedFeatures(config);
     }
 
     async getHomeHeaderFeedFeatures() {

--- a/src/data/utils.js
+++ b/src/data/utils.js
@@ -63,6 +63,7 @@ export const createVideoUrlFromGuid = (uri) =>
 const contentSingleTag = (strings, id) => `christfellowship://c/ContentSingle?itemId=${strings[0]}${id}`
 const contentFeedTag = (strings, id) => `christfellowship://c/ContentFeed?itemId=${strings[0]}${id}&nested=true`
 export const generateAppLinkFromUrl = async (uri, context) => {
+  const externalLinks = ['cf.church/pushpay', 'cf.church/paypal', 'cf.church/cash-app', 'cf.church/venmo']
   const parsedUrl = URL.parse(uri)
   const host = parsedUrl.host
 
@@ -91,7 +92,7 @@ export const generateAppLinkFromUrl = async (uri, context) => {
           return contentFeedTag`UniversalContentItem:${id}`
       }
     }
-  } else if (host === "pushpay.com") {
+  } else if (host === "pushpay.com" || externalLinks.includes(`${parsedUrl.host}${parsedUrl.pathname}`)) {
     return `${parsedUrl.protocol}//${parsedUrl.host}${parsedUrl.pathname}?mobileApp=external&${parsedUrl.query || ''}`
   }
 


### PR DESCRIPTION
Quick gut check on this PR!

This PR enables a bunch of new UI Elements on the 5.4.0 update. These UI elements are "version flagged" meaning that they require a mobile client of at least 5.4.0 or later to show.

The PR does not immediately enable these UI elements, but rather links up the elements to Rock in order to allow for CM's to enable it at their will.

1. Horizontal Card List Feed Feature
2. Action Bar updates for Give Feed
3. Action Bar url update for Profile Feed