### PR TITLE
Read the comments for a better description

### DIFF
--- a/src/data/live-stream/data-source.js
+++ b/src/data/live-stream/data-source.js
@@ -185,8 +185,6 @@ export default class LiveStream extends matrixItemDataSource {
         ','
       ).filter(dv => !!dv)
 
-      console.log({securityDataViews, personas})
-
       if (securityDataViews.length > 0) {
         /**
          * If there is at least 1 guid, we are going to check to see if the current user

--- a/src/data/schedule/data-source.js
+++ b/src/data/schedule/data-source.js
@@ -275,7 +275,7 @@ export default class Schedule extends RockApolloDataSource {
      * 
      * Instead of using the "relative" time zone identifier (America/New_York), we calculate
      * the current offset of America/New_York (either +5 or -4) and then manually create the
-     * explicit offset time zone (GMT+5 or GMT+4) in order to resolve the discrepency
+     * explicit offset time zone (GMT+5 or GMT+4) in order to resolve the discrepancy
      */
     const iCalStart = iCal.match(/DTSTART:(\w+)/s);
     const iCalEnd = iCal.match(/DTEND:(\w+)/s);


### PR DESCRIPTION
***Fix to some time zone inconsistencies specifically within the parseiCalendar method***

Before parsing the iCal object, we need to find and replace the start and end data/time with one that specifies the current timezone of the event

Rock returns a DTSTART/DTEND in the following format: DTSTART:20200419T171500 which is ambiguous to the time zone, so node-ical will pick the locale of the current machine in which the program is running.

When an event starts, the offset for the first date instance is what the parser uses for _all_ dates. This would mean that a repeated event set up before DLS would have an offset of -4 that carries with it into DLS. 

Ex: 4pm before DLS becomes 3pm after DLS

Instead of using the "relative" time zone identifier (America/New_York), we calculate the current offset of America/New_York (either +5 or -4) and then manually create the explicit offset time zone (GMT+5 or GMT+4) in order to resolve the discrepancy