### PR TITLE
Hard code weekend schedules

### DIFF
--- a/src/data/content-item/data-source.js
+++ b/src/data/content-item/data-source.js
@@ -234,7 +234,7 @@ export default class ContentItem extends coreContentItem.dataSource {
         .get()
 
       if (eventItems != null) {
-        Cache.set({
+        await Cache.set({
           key: cachedKey,
           data: eventItems,
           expiresIn: 60 * 5 // 5 minute cache 

--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -85,7 +85,7 @@ export default class GroupItem extends baseGroup.dataSource {
       .first();
 
     if (group) {
-      Cache.set({
+      await Cache.set({
         key: cachedKey,
         data: group,
         expiresIn: 60 * 60 * 12, // 12 hour cache

--- a/src/data/live-stream/data-source.js
+++ b/src/data/live-stream/data-source.js
@@ -286,7 +286,11 @@ export default class LiveStream extends matrixItemDataSource {
   }
 
   async getLiveStreams(props) {
-    const dayOfWeek = moment().tz(TIMEZONE).format('dddd')
+    console.log({ now: moment().format() })
+
+    const dayOfWeek = moment.tz(TIMEZONE).format('dddd').toLowerCase()
+
+
     if (dayOfWeek === 'saturday' || dayOfWeek === 'sunday') {
       return this.weekendServiceIsLive(moment().utc().toISOString())
     }

--- a/src/data/live-stream/data-source.js
+++ b/src/data/live-stream/data-source.js
@@ -288,7 +288,7 @@ export default class LiveStream extends matrixItemDataSource {
   async getLiveStreams(props) {
     const dayOfWeek = moment.tz(TIMEZONE).format('dddd').toLowerCase()
 
-    if (dayOfWeek === 'saturday' || dayOfWeek === 'sunday' || dayOfWeek === "wednesday") {
+    if (dayOfWeek === 'saturday' || dayOfWeek === 'sunday' || dayOfWeek === "thursday") {
       return this.weekendServiceIsLive(moment().utc().toISOString())
     }
 

--- a/src/data/live-stream/data-source.js
+++ b/src/data/live-stream/data-source.js
@@ -286,12 +286,9 @@ export default class LiveStream extends matrixItemDataSource {
   }
 
   async getLiveStreams(props) {
-    console.log({ now: moment().format() })
-
     const dayOfWeek = moment.tz(TIMEZONE).format('dddd').toLowerCase()
 
-
-    if (dayOfWeek === 'saturday' || dayOfWeek === 'sunday') {
+    if (dayOfWeek === 'saturday' || dayOfWeek === 'sunday' || dayOfWeek === "wednesday") {
       return this.weekendServiceIsLive(moment().utc().toISOString())
     }
 

--- a/src/data/live-stream/data-source.js
+++ b/src/data/live-stream/data-source.js
@@ -100,13 +100,13 @@ export default class LiveStream extends matrixItemDataSource {
   async getLiveStreamContentItems() {
     const { Cache } = this.context.dataSources;
     const cachedKey = `${process.env.CONTENT}_liveStreamContentItems`
-    // const cachedValue = await Cache.get({
-    //   key: cachedKey,
-    // });
+    const cachedValue = await Cache.get({
+      key: cachedKey,
+    });
 
-    // if (cachedValue) {
-    //   return cachedValue;
-    // }
+    if (cachedValue) {
+      return cachedValue;
+    }
 
     // Get Events
     const { ContentItem, Schedule } = this.context.dataSources;
@@ -133,13 +133,13 @@ export default class LiveStream extends matrixItemDataSource {
       }
     }))
 
-    // if (liveStreamContentItemsWithNextOccurrences != null) {
-    //   Cache.set({
-    //     key: cachedKey,
-    //     data: liveStreamContentItemsWithNextOccurrences,
-    //     expiresIn: 60 // one minute cache 
-    //   });
-    // }
+    if (liveStreamContentItemsWithNextOccurrences != null) {
+      await Cache.set({
+        key: cachedKey,
+        data: liveStreamContentItemsWithNextOccurrences,
+        expiresIn: 60 * 10 // ten minute cache 
+      });
+    }
 
     return liveStreamContentItemsWithNextOccurrences;
   }
@@ -296,7 +296,7 @@ export default class LiveStream extends matrixItemDataSource {
       const attributeMatrix = await this.byAttributeMatrixTemplate({ anonymously })
 
       if (attributeMatrix != null) {
-        Cache.set({
+        await Cache.set({
           key: cachedKey,
           data: attributeMatrix,
           expiresIn: 60 // 60 minute

--- a/src/data/live-stream/resolver.js
+++ b/src/data/live-stream/resolver.js
@@ -78,7 +78,7 @@ const resolver = {
 
       return liveStreamDefaultActionItemsMapped.concat(liveStreamActionsItemsMapped);
     },
-    contentItem: ({ contentChannelItemId }, _, { models, dataSources }) => {
+    contentItem: ({ contentChannelItemId }, _, { dataSources }) => {
       if (contentChannelItemId) {
         const { ContentItem } = dataSources;
 

--- a/src/data/live-stream/resolver.js
+++ b/src/data/live-stream/resolver.js
@@ -29,6 +29,8 @@ const resolver = {
       return null;
     },
     actions: async ({ id, guid }, args, { dataSources }) => {
+      if (!id || id === "") return []
+
       const unresolvedNode = await dataSources.LiveStream.getRelatedNodeFromId(id);
       // Get Matrix Items
       const liveStreamActionsMatrixGuid = get(

--- a/src/data/live-stream/weekend-services.js
+++ b/src/data/live-stream/weekend-services.js
@@ -71,12 +71,12 @@ export default [
     {
         day: "thursday",
         start: {
-            hour: 8,
-            minute: 00
+            hour: 7,
+            minute: 55
         },
         end: {
             hour: 9,
-            minute: 00
+            minute: 15
         },
     },
 ]

--- a/src/data/live-stream/weekend-services.js
+++ b/src/data/live-stream/weekend-services.js
@@ -1,0 +1,71 @@
+/**
+ * Days and Times are in the America/New_York time zone
+ */
+export default [
+    {
+        day: "saturday",
+        start: {
+            hour: 17,
+            minute: 55
+        },
+        end: {
+            hour: 18,
+            minute: 35
+        },
+    },
+    {
+        day: "saturday",
+        start: {
+            hour: 20,
+            minute: 55
+        },
+        end: {
+            hour: 21,
+            minute: 35
+        },
+    },
+    {
+        day: "sunday",
+        start: {
+            hour: 6,
+            minute: 55
+        },
+        end: {
+            hour: 7,
+            minute: 35
+        },
+    },
+    {
+        day: "sunday",
+        start: {
+            hour: 8,
+            minute: 55
+        },
+        end: {
+            hour: 9,
+            minute: 35
+        },
+    },
+    {
+        day: "sunday",
+        start: {
+            hour: 10,
+            minute: 55
+        },
+        end: {
+            hour: 11,
+            minute: 35
+        },
+    },
+    {
+        day: "sunday",
+        start: {
+            hour: 12,
+            minute: 55
+        },
+        end: {
+            hour: 13,
+            minute: 35
+        },
+    },
+]

--- a/src/data/live-stream/weekend-services.js
+++ b/src/data/live-stream/weekend-services.js
@@ -68,4 +68,15 @@ export default [
             minute: 35
         },
     },
+    {
+        day: "thursday",
+        start: {
+            hour: 8,
+            minute: 00
+        },
+        end: {
+            hour: 9,
+            minute: 00
+        },
+    },
 ]


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
In order to help mitigate the load issues that we were seeing, this PR does a couple of things

* On Saturday and Sunday, no requests are made to Rock to check and see if a Live Stream is active
* Best practices implemented for a couple of Redis requests
* Cached `getRelatedNodeById`
* On Live Stream Actions, return `[]` if id is null or an empty string

[Loom Demo](https://www.loom.com/share/7f237c77b7c44cd0ae074302f308cc46)