### PR TITLE
Add VIEWED_ACTION to interaction enum

### DIFF
--- a/src/data/live-stream/schema.js
+++ b/src/data/live-stream/schema.js
@@ -44,8 +44,7 @@ export default gql`
   }
 
   extend type Query {
-    liveStream: LiveStream
-    @deprecated(reason: "Use liveStreams, there may be multiple.")
+    liveStream: LiveStream @deprecated(reason: "Use liveStreams, there may be multiple.")
     liveStreams: [LiveStream] @cacheControl(maxAge: 10)
 
     floatLeftLiveStream: LiveStream
@@ -55,5 +54,6 @@ export default gql`
   extend enum InteractionAction {
     LIVESTREAM_JOINED
     LIVESTREAM_CLOSED
+    VIEWED_ACTION
   }
 `;


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Adds a new action type to the interaction enum for live stream actions

### 2. How do I test this PR?
Fire up the web-app on the `add-live-stream-action-interaction` branch and go to a live stream and click on an action. It should fire off the interactWithNode with the action of VIEWED_ACTION. We should also be able to see the interaction recorded in Rock.

## SCREENSHOTS/GIFS

| iOS | Android | Web |
| --- | ------- | --- |
|     |         |     |

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, storybook, or apps
- [x] Assign relevant reviewers
- [ ] Upload GIF(s) of iOS, Android, Web
- [ ] Get one peer approval before merging

## REVIEW:

**Manual QA**

- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
