### PR TITLE
[CFDP-1077] Schedule filter error

### DIFF
--- a/src/data/schedule/data-source.js
+++ b/src/data/schedule/data-source.js
@@ -215,6 +215,7 @@ export default class Schedule extends RockApolloDataSource {
      */
 
     const filteredDates = events
+      .filter((e) => !!e.start && !!e.end)
       .filter((e) => moment(e.start).isSameOrAfter(moment().startOf('day')))
       .sort(sortByTimeAsc);
     const closestDate = first(filteredDates);
@@ -222,12 +223,14 @@ export default class Schedule extends RockApolloDataSource {
     const nextEnd = get(closestDate, 'end');
 
     return {
-      nextStart: moment(nextStart).isValid()
-        ? moment.tz(nextStart, TIMEZONE).utc().format()
-        : null,
-      nextEnd: moment(nextEnd).isValid()
-        ? moment.tz(nextEnd, TIMEZONE).utc().format()
-        : null,
+      nextStart:
+        nextStart && moment(nextStart).isValid()
+          ? moment.tz(nextStart, TIMEZONE).utc().format()
+          : null,
+      nextEnd:
+        nextEnd && moment(nextEnd).isValid()
+          ? moment.tz(nextEnd, TIMEZONE).utc().format()
+          : null,
       startOffset: this.defaultStartOffsetMinutes,
       endOffset: this.defaultEndOffsetMinutes,
     };
@@ -342,6 +345,7 @@ export default class Schedule extends RockApolloDataSource {
            * end date of this specific occurence and convert to an ISO string
            * and push it to our array of events
            */
+
           events.push({
             start: this.toISOString(rdate),
             end: moment.utc(rdate).add(minutes, 'minutes').toISOString(),

--- a/src/data/url/data-source.js
+++ b/src/data/url/data-source.js
@@ -8,8 +8,6 @@ const { URLS: UrlDefinedTypeId } = DEFINED_TYPES;
 
 export default class Url extends RockApolloDataSource {
   getFromId(url) {
-    console.log({ url });
-
     // the url gets encoded as the id, so we can just return it with no fuss
     return url;
   }


### PR DESCRIPTION
## DESCRIPTION
Fixes an issue where Groups with no schedule were not getting filtered out, but rather returning with "TODAY" being the date

### 1. What does this PR do, or why is it needed?
Groups were not filtering correctly

### 2. What design trade-offs/decisions were made?
There was an issue where a null check wasn't happening with `moment` and it was instead just defaulting to today instead
