### PR TITLE
Use smaller preference and subPreference cover images

### DIFF
--- a/src/data/group-preferences/data-source.js
+++ b/src/data/group-preferences/data-source.js
@@ -5,6 +5,7 @@ const { ROCK_MAPPINGS } = ApollosConfig;
 import { Utils } from '@apollosproject/data-connector-rock';
 import { get } from 'lodash';
 
+import { rockImageUrl } from '../utils';
 const { createImageUrlFromGuid } = Utils;
 
 export default class GroupPreferences extends RockApolloDataSource {
@@ -19,6 +20,8 @@ export default class GroupPreferences extends RockApolloDataSource {
     );
 
     return filteredPreferences.map((item) => {
+      const coverImageGuid = get(item.attributeValues, 'image.value', null);
+
       return {
         id: item.id,
         title: get(item.attributeValues, 'titleOverride.value', null)
@@ -28,9 +31,16 @@ export default class GroupPreferences extends RockApolloDataSource {
         coverImage: {
           sources: [
             {
-              uri: get(item.attributeValues, 'image.value', null)
-                ? createImageUrlFromGuid(item.attributeValues.image.value)
-                : null,
+              uri: coverImageGuid ?
+                rockImageUrl(
+                  coverImageGuid,
+                  {
+                    w: 768,
+                    format: 'jpg',
+                    quality: 70,
+                  }
+                )
+                : null
             },
           ],
         },


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
There are ultra-high res cover image assets used in Rock for **Preference** and **SubPreference** `DefinedTypes`.

This PR uses the `rockImageUrl` method to transform the URL returned to clients, so they are shrunk down to smaller and optimized versions.

### 2. What design trade-offs/decisions were made?
None

### 3. How do I test this PR?
Run the following query in graphql, and verify there are transform parameters returned in the `coverImage.sources[0].uri` value (like `&w=768&quality=70&format=jpeg`)

```graphql
query preferencesAndSubPreferences {
  allPreferences {
    id
    title
    summary
    coverImage {
      sources {
        uri
      }
    }
  }
  allSubPreferences {
    id
    title
    summary
    coverImage {
      sources {
        uri
      }
    }
  }
}
```

### 4. What automated tests did you write?
None

## SCREENSHOTS/GIFS
<img src="https://user-images.githubusercontent.com/1812955/108392211-7be2b480-71e0-11eb-9935-cd363e41de8f.jpg" width="700"/>


## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, storybook, or apps
- [ ] Assign relevant reviewers
- [ ] Upload GIF(s) of iOS, Android, Web
- [ ] Get one peer approval before merging

## REVIEW:

**Manual QA**

- [ ] QA branch on iOS and ensure it looks/behaves as expected
- [ ] QA branch on Android and ensure it looks/behaves as expected
- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
