### PR TITLE
Index full day in group index

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -1198,7 +1198,7 @@ export default class GroupItem extends baseGroup.dataSource {
       title,
     } = data.node;
 
-    const dateTimeFormatted = moment(dateTime?.start).format('ddd');
+    const dateTimeFormatted = moment(dateTime?.start).format('dddd');
 
     // Remember — Algolia uses the order of attributes on items in its results
     // ranking logic, in lieu of other settings/custom ranking formula, etc.


### PR DESCRIPTION
## DESCRIPTION
This PR makes it so we index the full name of the day a group meets. If a user types `Monday` or anything shorter in the search they will get a match. Just indexing `Mon` in Algolia would not allow a user to get a match by typing `Monday`.

This will take effect the next time we index Algolia.

## TODO:

- [x] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [x] No new warnings in tests, storybook, or apps
- [x] Assign relevant reviewers
- [ ] Get one peer approval before merging

## REVIEW:

**Manual QA**

- [ ] QA branch on iOS and ensure it looks/behaves as expected
- [ ] QA branch on Android and ensure it looks/behaves as expected
- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
