### PR TITLE
[CFDP-1191] Filters when Zoom Buttons show up

### DIFF
--- a/src/data/checkinable/data-source.js
+++ b/src/data/checkinable/data-source.js
@@ -69,8 +69,6 @@ export default class Checkinable extends RockApolloDataSource {
     const { Schedule } = this.context.dataSources;
     const { nextStart, startOffset, endOffset } = await Schedule.parseById(scheduleId);
 
-    console.log({ nextStart, startOffset, endOffset });
-
     /** Check to make sure the nextStartDateTime is valid */
     if (nextStart && moment(nextStart).isValid()) {
       /** Beginning of the most recent instance */
@@ -102,8 +100,6 @@ export default class Checkinable extends RockApolloDataSource {
        *  for check in. This would mean that this schedule is valid between 6:30am
        *  and 7:30am
        */
-
-      console.log({ isActive, returnData });
 
       if (isActive) {
         if (moment().isBetween(checkInStart, checkInEnd)) {

--- a/src/data/checkinable/data-source.js
+++ b/src/data/checkinable/data-source.js
@@ -69,6 +69,8 @@ export default class Checkinable extends RockApolloDataSource {
     const { Schedule } = this.context.dataSources;
     const { nextStart, startOffset, endOffset } = await Schedule.parseById(scheduleId);
 
+    console.log({ nextStart, startOffset, endOffset });
+
     /** Check to make sure the nextStartDateTime is valid */
     if (nextStart && moment(nextStart).isValid()) {
       /** Beginning of the most recent instance */
@@ -100,6 +102,9 @@ export default class Checkinable extends RockApolloDataSource {
        *  for check in. This would mean that this schedule is valid between 6:30am
        *  and 7:30am
        */
+
+      console.log({ isActive, returnData });
+
       if (isActive) {
         if (moment().isBetween(checkInStart, checkInEnd)) {
           return returnData;

--- a/src/data/schedule/data-source.js
+++ b/src/data/schedule/data-source.js
@@ -199,9 +199,10 @@ export default class Schedule extends RockApolloDataSource {
     };
   }
 
-  async _parseCustomSchedule(iCalendar) {
+  async _parseCustomSchedule(iCalendar, args) {
+    const duration = get(args, 'duration', this.defaultEndOffsetMinutes);
     const events = await this.parseiCalendar(iCalendar, {
-      duration: this.defaultEndOffsetMinutes,
+      duration,
     });
 
     /** TL;DR: parseiCalendar filters by the _day_ of the event, not the time
@@ -398,6 +399,9 @@ export default class Schedule extends RockApolloDataSource {
 
   timeIsInSchedules = async ({ ids, time }) => {
     const times = await this.getOccurrencesFromIds(ids);
+
+    console.log({ times });
+
     const nextTime = first(times);
 
     if (nextTime) {

--- a/src/data/schedule/data-source.js
+++ b/src/data/schedule/data-source.js
@@ -400,8 +400,6 @@ export default class Schedule extends RockApolloDataSource {
   timeIsInSchedules = async ({ ids, time }) => {
     const times = await this.getOccurrencesFromIds(ids);
 
-    console.log({ times });
-
     const nextTime = first(times);
 
     if (nextTime) {


### PR DESCRIPTION
* video calls require a user to be logged in to access
* video calls only show when the group is currently active
* duration of the Group is defaulted to 4 hours from the start time

## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Group Video buttons should only be visible when the Group is currently meeting

### 2. What design trade-offs/decisions were made?
Groups in Rock don't have a duration, so we've defaulted the duration to 4 hours from the start time of the group

### 3. How do I test this PR?
Query for a bunch of Groups to see if the video calls show up as expected

### 4. What automated tests did you write?
n/a