### PR TITLE
[CFDP-1203] Group Duplication

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -1072,8 +1072,6 @@ export default class GroupItem extends baseGroup.dataSource {
         .filter((groupTypeId) => !!groupTypeId)
         .filter((groupTypeId, index, self) => self.indexOf(groupTypeId) === index);
 
-      console.log({ groupTypeIds });
-
       return Promise.all(
         groupTypeIds.map((groupTypeId) => {
           if (groupTypeId) {


### PR DESCRIPTION
Groups were being queried with an array of Group Types that were not unique. This meant that a Group Type Ids array could look like [1, 1, 1, 1, 1, 1, 1, 1] in which the exact same groups were queried and returned multiple times.

This caused extensive loading times and extra strain on Rock. This has been resolved by making sure that the Group Type Ids array that's returned is a unique array.