### PR TITLE
[CFDP-1251] Fix for Page Builder Bug

### DIFF
--- a/src/data/content-item/data-source.js
+++ b/src/data/content-item/data-source.js
@@ -26,55 +26,56 @@ const cleanHtmlContentForIndex = (htmlContent) => {
   // Strip all html tags
   const cleanedHtml = sanitizeHtml(htmlContent, {
     allowedTags: [],
-    allowedAttributes: {}
-  })
+    allowedAttributes: {},
+  });
 
   return keywordExtractor.extract(cleanedHtml, {
-    language: "english",
+    language: 'english',
     remove_digits: true,
     return_changed_case: true,
-    remove_duplicates: true
-  })
+    remove_duplicates: true,
+  });
 };
 
 const processObjectSize = (obj) => {
-  const objSize = sizeof(obj)
+  const objSize = sizeof(obj);
 
   // If the object is smaller than the max size, return it
-  if (objSize < MAX_SIZE) return obj
+  if (objSize < MAX_SIZE) return obj;
 
   // Calculate the size of the htmlContent and the rest of the props
-  const htmlContentSize = sizeof(obj.htmlContent)
-  const objPropSize = objSize - htmlContentSize
+  const htmlContentSize = sizeof(obj.htmlContent);
+  const objPropSize = objSize - htmlContentSize;
 
   if (objPropSize > MAX_SIZE) {
     // TODO : handle an object that exceeds the max size without any htmlContent
-    return obj
+    return obj;
   }
 
   // Calculate the max size that the html content array can be.
-  const maxContentSize = MAX_SIZE - objPropSize
+  const maxContentSize = MAX_SIZE - objPropSize;
   // Calculate the new length of the array based on the % reduction
   // that needs to be had. It's not exact, but it should be decent
   // enough for right now.
   //
   // Ex: if we need a 50% reduction in the array size, cut the array's
   // length in half
-  const percentReduction = maxContentSize / htmlContentSize
-  const newArrayLength = obj.htmlContent.length - (obj.htmlContent.length * percentReduction)
+  const percentReduction = maxContentSize / htmlContentSize;
+  const newArrayLength =
+    obj.htmlContent.length - obj.htmlContent.length * percentReduction;
 
   return {
     ...obj,
-    htmlContent: take(obj.htmlContent, newArrayLength)
-  }
-}
+    htmlContent: take(obj.htmlContent, newArrayLength),
+  };
+};
 
 const deleteKeysByPattern = (pattern) => {
   return new Promise((resolve, reject) => {
     const stream = redis.scanStream({
-      match: pattern
+      match: pattern,
     });
-    stream.on("data", (keys) => {
+    stream.on('data', (keys) => {
       if (keys.length) {
         const pipeline = redis.pipeline();
         keys.forEach((key) => {
@@ -83,10 +84,10 @@ const deleteKeysByPattern = (pattern) => {
         pipeline.exec();
       }
     });
-    stream.on("end", () => {
+    stream.on('end', () => {
       resolve();
     });
-    stream.on("error", (e) => {
+    stream.on('error', (e) => {
       reject(e);
     });
   });
@@ -107,18 +108,21 @@ export default class ContentItem extends coreContentItem.dataSource {
     /**
      * Find the Association Order for the given content channel items
      */
-    const { order: orderA } = associations.find(
-      (item) => item.childContentChannelItemId === a.id
-    );
-    const { order: orderB } = associations.find(
-      (item) => item.childContentChannelItemId === b.id
-    );
+    if (associations.childContentChannelItemId) {
+      const { order: orderA } = associations.find(
+        (item) => item.childContentChannelItemId === a.id
+      );
+      const { order: orderB } = associations.find(
+        (item) => item.childContentChannelItemId === b.id
+      );
 
-    /**
-     * Compare functions want either `0`, `< 0` or `> 0` as a return value, so we'll just subtract
-     * orderA - orderB in order to mimic the `Order asc` request
-     */
-    return orderA - orderB;
+      /**
+       * Compare functions want either `0`, `< 0` or `> 0` as a return value, so we'll just subtract
+       * orderA - orderB in order to mimic the `Order asc` request
+       */
+      return orderA - orderB;
+    }
+    return null;
   };
 
   CONTENT_ITEM_ASSOCIATION_SORT = () => [{ field: 'Order', direction: 'asc' }];
@@ -550,9 +554,8 @@ export default class ContentItem extends coreContentItem.dataSource {
   }
 
   async indexAllGeneralContent() {
-    const contentItems = await this
-      .request()
-      .filterOneOf([43, 45, 60, 63].map(n => `ContentChannelId eq ${n}`))
+    const contentItems = await this.request()
+      .filterOneOf([43, 45, 60, 63].map((n) => `ContentChannelId eq ${n}`))
       .andFilter(this.byActive())
       .get();
 
@@ -587,14 +590,14 @@ export default class ContentItem extends coreContentItem.dataSource {
 
     return processObjectSize({
       ...data.node,
-      htmlContent: cleanHtmlContentForIndex(data.node.htmlContent)
+      htmlContent: cleanHtmlContentForIndex(data.node.htmlContent),
     });
   }
 
   async updateContentItemIndex(id) {
     // const log = (msg) => console.log(`\n\x1b[35m${msg}\x1b[30m\n`);
     const log = (msg) => console.log(`\n*** Search Index Log ***\n${msg}\n\n`);
-    log(`updateContentItemIndex(${id})`)
+    log(`updateContentItemIndex(${id})`);
 
     /** Resolve the Content Item */
     const item = await this.getFromId(id);
@@ -602,10 +605,14 @@ export default class ContentItem extends coreContentItem.dataSource {
       return null;
     }
 
-    const hideFromSearch = get(item, "attributeValues.hideFromSearch.value", "false").toLowerCase();
+    const hideFromSearch = get(
+      item,
+      'attributeValues.hideFromSearch.value',
+      'false'
+    ).toLowerCase();
 
     /** Delete the item if it should not be included in Search */
-    if (hideFromSearch === "true") {
+    if (hideFromSearch === 'true') {
       const type = await this.resolveContentItem(item);
       return this.getSearchIndex().deleteObject(createGlobalId(item.id, type));
     }
@@ -630,7 +637,11 @@ export default class ContentItem extends coreContentItem.dataSource {
     if (startDateTime && startDateTime !== '') {
       const mStartDateTime = moment(startDateTime).tz(ApollosConfig.ROCK.TIMEZONE);
 
-      log(`${moment().format()} : ${item.title} has a start date of ${mStartDateTime.format()}`);
+      log(
+        `${moment().format()} : ${
+          item.title
+        } has a start date of ${mStartDateTime.format()}`
+      );
 
       if (mStartDateTime.isValid() && mStartDateTime.isAfter(moment())) {
         /** Set up the options for the bull job.
@@ -651,7 +662,7 @@ export default class ContentItem extends coreContentItem.dataSource {
         const data = {
           action: 'update',
           item: indexableItem,
-          timestamp: moment().format('hh:mm:ss')
+          timestamp: moment().format('hh:mm:ss'),
         };
         const options = {
           delay: mStartDateTime.diff(moment()),
@@ -659,9 +670,9 @@ export default class ContentItem extends coreContentItem.dataSource {
           prefix: `bull-${CONTENT}`,
         };
 
-        log(`Scheduling search index update for "${item.title}"`)
+        log(`Scheduling search index update for "${item.title}"`);
         itemQueue.add(data, options);
-        itemQueue.process(job => {
+        itemQueue.process((job) => {
           /** Get the item from our job data so that we can go ahead
            *  and execute our search
            *
@@ -670,18 +681,18 @@ export default class ContentItem extends coreContentItem.dataSource {
           const { data } = job;
           const { action, item } = data;
 
-          if (action === "update") {
+          if (action === 'update') {
             log(`Running scheduled search index update for "${item.title}"`);
             return this.getSearchIndex().addObjects([item]);
           }
         });
 
-        return null
+        return null;
       }
     }
 
-    log(`Updating search index for "${item.title}"`)
-    return this.getSearchIndex().addObjects([indexableItem])
+    log(`Updating search index for "${item.title}"`);
+    return this.getSearchIndex().addObjects([indexableItem]);
   }
 
   async deltaIndex({ datetime }) {


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
The `sortByAssociationOrder` method seemed to be breaking for pages using the Page Builder content items that returned a null `childContentChannelItemId`. I added a catch for it.

### 3. How do I test this PR?
Go to `/jupiter-plan-your-visit` page that was previously breaking on master.

## REVIEW:

**Manual QA**

- [ ] QA branch on iOS and ensure it looks/behaves as expected
- [ ] QA branch on Android and ensure it looks/behaves as expected
- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
