### PR TITLE
Fix groups resources delete

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -334,24 +334,29 @@ export default class GroupItem extends baseGroup.dataSource {
   async groupResourceEntity({ groupId, relatedNodeId }) {
     const groupGlobalId = parseGlobalId(groupId)?.id;
     const relatedNodeGlobalId = parseGlobalId(relatedNodeId);
+    let targetEntityId = null;
+
     let entityTypeId;
     switch (relatedNodeGlobalId.__type) {
       case 'Url':
+        const jsonNode = JSON.parse(relatedNodeGlobalId.id);
+        targetEntityId = jsonNode.id;
         entityTypeId = ApollosConfig.ROCK_ENTITY_IDS.DEFINED_VALUE;
         break;
       case 'MediaContentItem':
         entityTypeId = ApollosConfig.ROCK_ENTITY_IDS.CONTENT_CHANNEL_ITEM;
+        targetEntityId = relatedNodeGlobalId.id;
         break;
       default:
         break;
     }
-    if (entityTypeId) {
+    if (entityTypeId && targetEntityId) {
       return await this.request('/RelatedEntities')
         .filter(`SourceEntityTypeId eq ${ApollosConfig.ROCK_ENTITY_IDS.GROUP}`)
         .andFilter(`SourceEntityId eq ${groupGlobalId}`)
         .andFilter(`QualifierValue eq 'APOLLOS_GROUP_RESOURCE'`)
         .andFilter(`TargetEntityTypeId eq ${entityTypeId}`)
-        .andFilter(`TargetEntityId eq ${relatedNodeGlobalId.id}`)
+        .andFilter(`TargetEntityId eq ${targetEntityId}`)
         .first();
     }
 

--- a/src/data/url/data-source.js
+++ b/src/data/url/data-source.js
@@ -37,6 +37,7 @@ export default class Url extends RockApolloDataSource {
     return {
       url,
       title: get(definedValue, 'value'),
+      id: get(definedValue, 'id'),
     };
   }
 

--- a/src/data/url/data-source.js
+++ b/src/data/url/data-source.js
@@ -7,9 +7,10 @@ const { DEFINED_TYPES } = ROCK_MAPPINGS;
 const { URLS: UrlDefinedTypeId } = DEFINED_TYPES;
 
 export default class Url extends RockApolloDataSource {
-  getFromId(url) {
-    // the url gets encoded as the id, so we can just return it with no fuss
-    return { url };
+  getFromId(root) {
+    const json = JSON.parse(root);
+
+    return json;
   }
 
   resolveType() {

--- a/src/data/url/resolver.js
+++ b/src/data/url/resolver.js
@@ -7,8 +7,8 @@ const { CONTENT_CHANNEL_PATHNAMES } = ROCK_MAPPINGS;
 
 const resolver = {
   Url: {
-    id: ({ url }, args, context, { parentType }) => {
-      return createGlobalId(url, parentType.name);
+    id: ({ id }, args, context, { parentType }) => {
+      return createGlobalId(id, parentType.name);
     },
   },
   Route: {

--- a/src/data/url/resolver.js
+++ b/src/data/url/resolver.js
@@ -7,8 +7,8 @@ const { CONTENT_CHANNEL_PATHNAMES } = ROCK_MAPPINGS;
 
 const resolver = {
   Url: {
-    id: ({ id }, args, context, { parentType }) => {
-      return createGlobalId(id, parentType.name);
+    id: (root, args, context, { parentType }) => {
+      return createGlobalId(JSON.stringify(root), parentType.name);
     },
   },
   Route: {


### PR DESCRIPTION
## DESCRIPTION
closes: #228 

This [PATCH](https://github.com/christfellowshipchurch/apollos-api/commit/a23153a916109770e2934ae5057d5443688a755b) broke deleting resources. 

@asleepingpanda do you have a suggestion on how to fix this, but also address your PATCH changes? We need the TargetEntityId as the id to be able to delete the resource.

![image](https://user-images.githubusercontent.com/2528817/116480829-b05d9700-a847-11eb-9168-073a2a56c5a9.png)


