### PR TITLE
Check root of Url id before attempting to parse the id

### DIFF
--- a/src/data/url/data-source.js
+++ b/src/data/url/data-source.js
@@ -6,11 +6,39 @@ const { ROCK_MAPPINGS } = ApollosConfig;
 const { DEFINED_TYPES } = ROCK_MAPPINGS;
 const { URLS: UrlDefinedTypeId } = DEFINED_TYPES;
 
+function validURL(str) {
+  var pattern = new RegExp(
+    '^(https?:\\/\\/)?' + // protocol
+      '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + // domain name
+      '((\\d{1,3}\\.){3}\\d{1,3}))' + // OR ip (v4) address
+      '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' + // port and path
+      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      '(\\#[-a-z\\d_]*)?$',
+    'i'
+  ); // fragment locator
+  return !!pattern.test(str);
+}
+
 export default class Url extends RockApolloDataSource {
   getFromId(root) {
-    const json = JSON.parse(root);
+    if (
+      /^[\],:{}\s]*$/.test(
+        root
+          .replace(/\\["\\\/bfnrtu]/g, '@')
+          .replace(
+            /"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,
+            ']'
+          )
+          .replace(/(?:^|:|,)(?:\s*\[)+/g, '')
+      )
+    ) {
+      const json = JSON.parse(root);
+      return json;
+    } else if (validURL(root)) {
+      return { url: root };
+    }
 
-    return json;
+    return null;
   }
 
   resolveType() {


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
There is a phantom bug out right now where people updating from mobile app v5.4.0 --> v6.0.0 are getting a "white screen of death" when navigating to the Give screen.

What I noticed was that the 1.0 and 2.0 API's are returning different Id's for the same Url. 

For example:
Given the Url: https://cf.church/pushpay?feed=give
V1 API Node Id: `Url:00f6c0472e9887c9a2e494f04992ce8a41543e8160a5195f738931b99ae6f3c2a8a0a3aaffa54f5ce8efe95b70a081cb`

V2 API Node Id: `Url:f4974a223763b3a06ea2cd73ff30952be89d6281e05bc41f7ee423cd227a2b008149a76a099525a2281fbe97f73d11782cdbcae8821e26fa417069f1368ec6d8cc0ef4040d2f2e617c9d5192457c82a7d8603ba7b623bee8863c730a7fa1dfaa74936570206d0917e4feb0d71dc6617a6249eeca3a2f250e668315346de25e32dc5bf9c46ca5f971c1abca71348c34fe03854c9a8765238cfb61988ada8f4996`

Run a `node` query on the 2.0 API using the 1.0 Node Id and you'll see the following error:
`"message": "Unexpected token h in JSON at position 0"`

The running theory: when upgrading from 5.4 to 6.0, there is a cached Id for the Url on Device that is attempting to be parsed by the 2.0 server and is failing.

### 2. What design trade-offs/decisions were made?
There is now a bit of Regex that checks to see if the root of the id being passed into `Url.getFromId` is a valid JSON object. If it is, parse the object.

Then, we check to see if the root string is a valid url. If so, return the string as a Url nested in an object (mimicking the final url return object)

Otherwise, just return null as a catch all.

### 3. How do I test this PR?
Run a couple of Node queries using Url Ids generated from the 1.0 API on this branch.
