### PR TITLE
Group chat data syncing cleanup

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -947,7 +947,6 @@ export default class GroupItem extends baseGroup.dataSource {
   };
 
   getStreamChatChannel = async (root) => {
-    console.log('🟧 getStreamChatChannel()');
     const { Auth, StreamChat } = this.context.dataSources;
     const channelType = StreamChat.channelType.GROUP;
     const groupType = this.resolveType(root);

--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -947,24 +947,24 @@ export default class GroupItem extends baseGroup.dataSource {
   };
 
   getStreamChatChannel = async (root) => {
-    const { Auth, StreamChat } = this.context.dataSources;
-    const channelType = StreamChat.channelType.GROUP;
-    const groupType = this.resolveType(root);
-
-    const groupName = this.getTitle(root);
-    const currentPerson = await Auth.getCurrentPerson();
-    const resolvedType = this.resolveType(root);
-    const globalId = createGlobalId(root.id, resolvedType);
-    const channelId = crypto.SHA1(globalId).toString();
-
-    // Define the return value upfront
-    const streamChatChannel = {
-      id: root.id,
-      channelId,
-      channelType,
-    };
-
     try {
+      const { Auth, StreamChat } = this.context.dataSources;
+      const channelType = StreamChat.channelType.GROUP;
+      const groupType = this.resolveType(root);
+
+      const groupName = this.getTitle(root);
+      const currentPerson = await Auth.getCurrentPerson();
+      const resolvedType = this.resolveType(root);
+      const globalId = createGlobalId(root.id, resolvedType);
+      const channelId = crypto.SHA1(globalId).toString();
+
+      // Define the return value upfront
+      const streamChatChannel = {
+        id: root.id,
+        channelId,
+        channelType,
+      };
+
       // Get or create the channel. The options are only applied to the channel if
       // creating it for the first time. We'll update the values further down if necessary.
       const channel = await StreamChat.getChannel({


### PR DESCRIPTION
# About

Closes #233 
Closes #235 

Add meta data on group chat channels for `lastSyncedWithRockAt`. The intention is to limit the costly operation of fetching all members and leaders and add/removing/promoting/demoting everyone in the group chat channel as needed. This currently happens every request for a group's `streamChatChannel` node, but this PR modifies it to happen at most once per 24hrs.

Should also fix a sneaky bug (or potential/inevitable bugs) around updating channels after they've been created, i.e. managing the array of users who have muted notifications.

Removes the `GROUP_CHAT` feature flag checks since it's technically live now.

# Testing

For development and testing, I used a hard coded channel ID that was easy to find in [our Stream dashboard](https://dashboard.getstream.io/dashboard/v2/organization/52167/app/88211/chat/explorer?path=channels,ryan-group-members-test-2,members). I spent considerable time sanity checking flows like changing a name after it's created, adding/removing members, etc this way.

You can see the channel metadata listed on the dashboard.
Experiment however you deem fit, or trust that I've done due diligence 🙃 .

![CleanShot_2021-05-06_11 32 03](https://user-images.githubusercontent.com/1812955/117325545-cfb77e00-ae5e-11eb-833f-8dbb863b2830.jpg)

**Query to fetch your groups and their `streamChatChannel` nodes**
_Don't forget to include an `authorization` HTTP header!_
```grapqhl
query myGroups {
  currentUser {
    profile {
      groups {
        title
        ... on Group {
          id
          streamChatChannel {
            id
            channelId
            channelType
          }
        }
      }
    }
  }
}
```
