### PR TITLE
Enforces an http protocol at the beginning of the url string

### DIFF
--- a/src/data/url/data-source.js
+++ b/src/data/url/data-source.js
@@ -74,7 +74,12 @@ export default class Url extends RockApolloDataSource {
    * Adds a url to the master list of urls
    * @param {string} url
    */
-  async addToMasterList({ url, title }) {
+  async addToMasterList({ url: rawUrl, title }) {
+    /**
+     * note : checks to make sure that there is an http protocol enforced at the beginning of every url
+     */
+    const url = rawUrl.startsWith('http') ? rawUrl : `https://${rawUrl}`;
+
     /**
      * Check to see if the url exists today
      */


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
When a user adds a url, they don't know to add the http protocol to the beginning of the string and it ends up messing up routing on the website. 

It's a rudimentary and immature path, but it works for this specific use case. Before posting a Url to Rock, we will update the url to include `https://` at the beginning of the string if it doesn't exist already.