### PR TITLE
Updated cover image to use getImages method

### DIFF
--- a/src/data/features/data-source.js
+++ b/src/data/features/data-source.js
@@ -105,6 +105,8 @@ export default class Feature extends coreFeatures.dataSource {
       orientation = definedValue?.value ? definedValue?.value : orientation;
     }
 
+    const grabContentImages = await ContentItem.getImages(contentItem)
+
     return {
       // The Feature ID is based on all of the action ids, added together.
       // This is naive, and could be improved.
@@ -117,7 +119,7 @@ export default class Feature extends coreFeatures.dataSource {
       subtitle: get(contentItem, 'attributeValues.summary.value', ''),
       summary,
       htmlContent: sanitizeHtml(contentItem.content),
-      coverImage: ContentItem.getCoverImage(contentItem),
+      coverImage: grabContentImages[0],
       orientation: orientation.toUpperCase(),
       actions: actionsKeyValue.map(({ title, url }) => ({
         title,


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
The `ContentBlockFeature` was not allowing us to return a contentItem without an image and would grab the header image from the website page. To fix this we updated `coverImage` to use`getImages()` method instead so it would NOT grab the header image and return a `null` value.
