### PR TITLE
Add group facet filters

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -1477,6 +1477,13 @@ export default class GroupItem extends baseGroup.dataSource {
     return Object.keys(facets);
   };
 
+  getGroupFacetsByFilters = async (facet, facetFilters) => {
+    const { GroupItem } = this.context.dataSources;
+
+    const facets = await GroupItem.getSearchIndex().byFacetFilters(facet, facetFilters);
+    return Object.keys(facets[facet]);
+  };
+
   /**  :: Contact Group Leader
    * --------------------------------------------------------------------------
    * This workflow is triggered when a user clicks 'contact' leader

--- a/src/data/group-item/resolver.js
+++ b/src/data/group-item/resolver.js
@@ -208,6 +208,8 @@ const resolver = {
       dataSources.GroupItem.getGroupSearchOptions(),
     groupSearchFacetsAttributes: async (root, args, { dataSources }) =>
       dataSources.GroupItem.getGroupSearchFacetsAttributes(),
+    groupFacetFilters: async (root, { facet, facetFilters }, { dataSources }) =>
+      dataSources.GroupItem.getGroupFacetsByFilters(facet, facetFilters),
   },
 };
 

--- a/src/data/group-item/schema.js
+++ b/src/data/group-item/schema.js
@@ -165,6 +165,7 @@ export const groupSchema = gql`
     currentUserVolunteerGroups(first: Int, after: String): NodeConnection
     groupSearchOptions: GroupSearchFacetsOptions
     groupSearchFacetsAttributes: [String]
+    groupFacetFilters(facet: String, facetFilters: [String]): [String]
   }
 
   type GroupSearchFacetsOptions {

--- a/src/data/search/search-index.js
+++ b/src/data/search/search-index.js
@@ -62,12 +62,20 @@ export default class SearchIndex {
       edges: hits.map((hit, i) => ({
         ...hit,
         cursor: createCursor({ position: i + offset }),
-      }))
+      })),
     };
   }
 
   async byFacets() {
     const { facets } = await this.index.search('', { facets: ['*'] });
+    return facets;
+  }
+
+  async byFacetFilters(facet, facetFilters) {
+    const { facets } = await this.index.search('', {
+      facets: facet,
+      facetFilters,
+    });
     return facets;
   }
 }


### PR DESCRIPTION
## DESCRIPTION
A performant way to qualify what subPreferences a preference has, instead of querying all groups and filtering.

This is needed for only showing relevant lineup type. See PR https://github.com/christfellowshipchurch/web-app-v2/pull/175

query
```
  query getGroupFacetFilters {
    groupFacetFilters(facet: "subPreference", facetFilters: ["preference:Crew"])
  }
```

return

```
{
  "data": {
    "groupFacetFilters": [
      "Pray Together",
      "Study Together"
    ]
  }
}
```

## REVIEW:

**Manual QA**

- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
