### PR TITLE
Hide Title from Content Block

### DIFF
--- a/src/data/features/data-source.js
+++ b/src/data/features/data-source.js
@@ -38,7 +38,9 @@ export default class Feature extends coreFeatures.dataSource {
       actions: actions.map((action) => {
         // Ensures that we have a generated ID for the Primary Action related node, if not provided.
         if (action && action.relatedNode && !action.relatedNode.id) {
-          action.relatedNode.id = this.createFeatureId({ args: action.relatedNode });
+          action.relatedNode.id = this.createFeatureId({
+            args: action.relatedNode,
+          });
         }
 
         return action;
@@ -96,6 +98,7 @@ export default class Feature extends coreFeatures.dataSource {
     );
     const actionsAttributeValue = get(contentItem, 'attributeValues.actions.value', '');
     const actionsKeyValue = parseRockKeyValuePairs(actionsAttributeValue, 'title', 'url');
+    const hideTitle = get(contentItem, 'attributeValues.hideTitle.value', 'false');
 
     let orientation = 'LEFT';
 
@@ -115,7 +118,7 @@ export default class Feature extends coreFeatures.dataSource {
           contentChannelItemId,
         },
       }),
-      title: contentItem.title,
+      title: hideTitle.toLowerCase() === 'true' ? '' : contentItem.title,
       subtitle: get(contentItem, 'attributeValues.summary.value', ''),
       summary,
       htmlContent: sanitizeHtml(contentItem.content),
@@ -229,8 +232,8 @@ export default class Feature extends coreFeatures.dataSource {
   }
 
   /** Create Feeds */
-  getFeatures = async (featuresConfig = [], args = {}) => {
-    return Promise.all(
+  getFeatures = async (featuresConfig = [], args = {}) =>
+    Promise.all(
       featuresConfig.map((featureConfig) => {
         const featureMap = this.FEATURE_MAP || {};
         // Lookup the feature function, based on the name, and run it.
@@ -242,17 +245,12 @@ export default class Feature extends coreFeatures.dataSource {
             console.warn(
               'Deprecated: Please use the name "HeroList" instead. You used "HeroListFeature"'
             );
-            return featureMap['HeroList'](finalConfig);
+            return featureMap.HeroList(finalConfig);
           }
 
-          const featureMethod = get(
-            featureMap,
-            finalConfig.type,
-            featureMap['ActionList']
-          );
+          const featureMethod = get(featureMap, finalConfig.type, featureMap.ActionList);
           return featureMethod(finalConfig);
         }
       })
     );
-  };
 }


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Content Managers requested the ability to create a Content Block that just contained an Image and no additional text content.

### 2. What design trade-offs/decisions were made?
This could have been added as a part of the resolver, but for right now, it's only needed when a Content Manager manually selects the "Hide a Title" option on a _Content Item_ inside of Rock. For this reason, I opted to enable this in the `createContentBlock` method in the datasource and _not_ make it a global resolver update.

### 3. How do I test this PR?
I've attached 2 screenshots of a "before" and "after" using a Content Block inside of Rock with this feature enabled

Before
![Screen Shot 2021-05-18 at 2 38 14 PM](https://user-images.githubusercontent.com/45076058/118706865-ddb6b880-b7e7-11eb-9285-595ef2c3922a.png)

After
![Screen Shot 2021-05-18 at 2 47 03 PM](https://user-images.githubusercontent.com/45076058/118706943-f1fab580-b7e7-11eb-824a-21bca56c0dc5.png)

## Related Issues
[CFDP-1412]

[CFDP-1412]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1412