### PR TITLE
Add Content Channel route for /studies

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -165,12 +165,13 @@ ROCK_MAPPINGS:
 
   # For fetching Content Channel Items given a Web Pathname, this object maps the prefix to a specific channel to limit the scope of requests
   CONTENT_CHANNEL_PATHNAMES:
-    default: [85]
     articles: [43]
-    messages: [63]
+    default: [85]
     devotionals: [83]
     events: [78]
     locations: [88]
+    messages: [63]
+    studies: [80]
 
   GROUP:
     LEADER_ROLE_IDS:

--- a/src/data/page-builder/data-source.js
+++ b/src/data/page-builder/data-source.js
@@ -1,7 +1,7 @@
 import { ContentItem } from '@apollosproject/data-connector-rock';
 import ApollosConfig from '@apollosproject/config';
 import { get } from 'lodash';
-import { isType } from '../utils';
+import { isType, isRequired } from '../utils';
 
 export default class PageBuilder extends ContentItem.dataSource {
   async getFeatures(pathname) {


### PR DESCRIPTION
## What is this PR and why is it needed?
Introduces a new `/studies` route for a Content Channel specifically holding Studies & Series. This is primarily used for Groups, but needs to be available site-wide

## How to test?
![image](https://user-images.githubusercontent.com/45076058/118841876-b1a64080-b896-11eb-84b2-7b1b3b7d6a97.png)

## Related Issues
[CFDP-1396]

[CFDP-1396]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1396