### PR TITLE
Enables the "Primary Action" for Features

### DIFF
--- a/src/data/content-channel/data-source.js
+++ b/src/data/content-channel/data-source.js
@@ -83,10 +83,6 @@ export default class ContentChannel extends coreContentChannel.dataSource {
       return true;
     });
 
-    const { clientVersion } = this.context;
-    const versionParse = split(clientVersion, '.').join('');
-    const versionNumber = parseInt(versionParse);
-
     return Promise.all(
       filteredContentChannelItems.map(async (item) => {
         const action = get(item, 'attributeValues.action.value', '');
@@ -107,19 +103,19 @@ export default class ContentChannel extends coreContentChannel.dataSource {
               ],
               title: item.title,
               subtitle: ContentItem.createSummary(item),
-              // primaryAction: {
-              //   title: 'See More',
-              //   action: 'OPEN_URL',
-              //   relatedNode: {
-              //     __typename: 'Url',
-              //     url: 'https://christfellowship.church',
-              //   },
-              // },
+              primaryAction: {
+                title: 'See More',
+                action: 'OPEN_CHANNEL',
+                relatedNode: {
+                  __typename: 'UniversalContentItem',
+                  ...item,
+                },
+              },
             });
           case 'DefaultHorizontalCardList':
           case 'HighlightHorizontalCardList':
           case 'HighlightMediumHorizontalCardList':
-          case 'HighlightSmallHorizontalCardList':
+          case 'HighlightSmallHorizontalCardList': {
             // note : the total number of cards we want to show is 3
             const horizontalCardLimit = 3;
 
@@ -150,15 +146,16 @@ export default class ContentChannel extends coreContentChannel.dataSource {
               title: item.title,
               subtitle: ContentItem.createSummary(item),
               cardType: getCardType(),
-              // primaryAction: {
-              //   title: 'See More',
-              //   action: 'OPEN_URL',
-              //   relatedNode: {
-              //     __typename: 'Url',
-              //     url: 'https://christfellowship.church',
-              //   },
-              // },
+              primaryAction: {
+                title: 'See More',
+                action: 'OPEN_CHANNEL',
+                relatedNode: {
+                  __typename: 'UniversalContentItem',
+                  ...item,
+                },
+              },
             });
+          }
           case 'VIEW_CHILDREN': // ! deprecated, old action
           case 'VerticalCardList':
           default:

--- a/src/data/features/resolver.js
+++ b/src/data/features/resolver.js
@@ -12,6 +12,14 @@ const resolver = {
   ContentBlockFeature: {
     id: ({ id }) => createGlobalId(id, 'ContentBlockFeature'),
   },
+  HeroListFeature: {
+    primaryAction: ({ actions, primaryAction }) =>
+      actions.length > 3 ? primaryAction : null,
+  },
+  HorizontalCardListFeature: {
+    primaryAction: ({ cards, primaryAction }) =>
+      cards.length > 3 ? primaryAction : null,
+  },
   HtmlBlockFeature: {
     id: ({ id }) => createGlobalId(id, 'HtmlBlockFeature'),
   },


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
It enables the Primary Action to show up on the Hero List and Horizontal Card List Feature. This will _only_ show up when the `actions` or `cards` is greater than 3. This is so that we can show the "See more" button on the Feature that takes them to a collection of _all_ children for the parent Content Item.

### 2. What design trade-offs/decisions were made?
The Primary Action should be calculated and returned as a finalized object wherever the Feature is being created.

The "filtering" of the primary action based on the number of cards is done on the `resolver`. This is to avoid needing to use extensive logic within the data source method that creates each Feature to wait for the algorithms to run.

The only consequence of this, though, is that the filtering logic is universal and will need to be rethought it we end up finding additional edge cases.

### 3. How do I test this PR?
Load up the Home Feed and look at various Features. There should be at least 1 that has more than 3 cards on it. Look at Horizontal and Hero features

## Related Issues
[CFDP-1449]

[CFDP-1449]: https://christfellowshipchurch.atlassian.net/browse/CFDP-1449