### PR TITLE
Update config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -138,7 +138,7 @@ ROCK_MAPPINGS:
       EntityType: ContentChannelItem
     InformationalContentItem:
       EntityType: ContentChannelItem
-      ContentChannelId: [45, 76]
+      ContentChannelId: [45, 60, 76]
     EventContentItem:
       EntityType: ContentChannelItem
       ContentChannelTypeId: [29]


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
In order to make certain Content Items more easily visible/backwards compatible on the new website, we are marking the Resources Content Channel from Rock as an InformationalContentItem so they will show up under the `/items/item-id` url pathname