### PR TITLE
Use less frequent schedule for Group Item indexing on staging

### DIFF
--- a/src/data/group-item/jobs.js
+++ b/src/data/group-item/jobs.js
@@ -37,7 +37,27 @@ const createJobs = ({ getContext, queues, trigger = () => null }) => {
     return context.dataSources.GroupItem.updateIndexAllGroups();
   });
 
-  FullIndexQueue.add(null, { repeat: { cron: '15 3 * * *' } });
+  let schedule;
+
+  switch (process.env.NODE_ENV) {
+    // Production
+    case 'production':
+      // 3:15am Every day
+      schedule = '15 3 * * *';
+      break;
+    // Staging
+    case 'test':
+      // 3:15am on M/W/F
+      schedule = '15 3 * * 1,3,5';
+      break;
+    // Dev
+    default:
+      // 3:15am Every Day
+      schedule = '15 3 * * *';
+      break;
+  }
+
+  FullIndexQueue.add(null, { repeat: { cron: schedule } });
 
   // add manual index trigger
   trigger('/manual-index', FullIndexQueue);


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Quick tweak to reduce Group Finder data indexing on the Staging environment to only M/W/F instead of every day.

### 2. What design trade-offs/decisions were made?
None

### 3. How do I test this PR?
Carefully read through the code 🤷‍♂️  and gut check my cron schedule syntax [with a reference cheat sheet](https://www.adminschoice.com/crontab-quick-reference).

### 4. What automated tests did you write?
None

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, storybook, or apps
- [ ] Assign relevant reviewers
- [ ] Upload GIF(s) of iOS, Android, Web
- [ ] Get one peer approval before merging

## REVIEW:

**Manual QA**

- [ ] QA branch on iOS and ensure it looks/behaves as expected
- [ ] QA branch on Android and ensure it looks/behaves as expected
- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
