### PR TITLE
Endpoint to get a collection of FeatureActions for Node Id

### DIFF
--- a/src/data/additional-endpoints/schema.js
+++ b/src/data/additional-endpoints/schema.js
@@ -24,6 +24,7 @@ export default gql`
     inAppLink(url: String!): String
     dannysContent: [ContentItem]
     getNodeByPathname(pathname: String): Node
+    nodeActions(nodeId: ID): [FeatureAction]
   }
 
   extend type MediaContentItem implements FeaturesNode {


### PR DESCRIPTION
Temporary endpoint for getting a collection of buttons from ALL content types.

To be replaced by a more robust solution in the future, I'm sure, but for right now it works.
