### PR TITLE
Increase stalled interval time for Group Item Bull queues

### DIFF
--- a/src/data/group-item/jobs.js
+++ b/src/data/group-item/jobs.js
@@ -23,6 +23,9 @@ if (REDIS_URL) {
           return new Redis(REDIS_URL);
       }
     },
+    settings: {
+      stalledInterval: 120000,
+    },
   };
 }
 


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?

Fixes #266

Bull cron jobs are being considered "stalled" because they don't respond for < 30s.
This allows up to 2min for a job to complete before counting it as stalled.

### 2. What design trade-offs/decisions were made?
N/A

### 3. How do I test this PR?
YOLO

### 4. What automated tests did you write?
N/A

## TODO:

- [ ] PR has a relevant title that will be understandable in a public changelog (ie...non developers)
- [ ] Closes [tag-issues-here]
- [ ] No new warnings in tests, storybook, or apps
- [ ] Assign relevant reviewers
- [ ] Upload GIF(s) of iOS, Android, Web
- [ ] Get one peer approval before merging

## REVIEW:

**Manual QA**

- [ ] QA branch on iOS and ensure it looks/behaves as expected
- [ ] QA branch on Android and ensure it looks/behaves as expected
- [ ] QA branch on Web and ensure it looks/behaves as expected

**Code Review**

- [ ] Read through the "Files changed" tab _very carefully_
- [ ] Edge cases: what assumptions are made about input?
- [ ] What kind of tests could be written?
- [ ] How might we make this easier for someone else to understand?
- [ ] Could the code be simpler?
- [ ] Will the code be easy to modify in the future?
- [ ] What's one part of these changes that makes you excited to merge it?

> The purpose of PR Review is to _improve the quality of the software._
