### PR TITLE
Group member status

### DIFF
--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -1586,7 +1586,7 @@ export default class GroupItem extends baseGroup.dataSource {
     const { Workflow, Auth } = this.context.dataSources;
     const currentUser = await Auth.getCurrentPerson();
 
-    switch ('FULL') {
+    switch (status) {
       case 'FULL':
         throw new ApolloError(
           'Could not add user to group. Group is full.',

--- a/src/data/group-item/resolver.js
+++ b/src/data/group-item/resolver.js
@@ -39,9 +39,8 @@ const resolver = {
     ...defaultResolvers,
     schedule: ({ scheduleId }, args, { dataSources }) =>
       dataSources.GroupItem.getScheduleFromId(scheduleId),
-    phoneNumbers: ({ id }, args, { dataSources }) => {
-      return dataSources.GroupItem.groupPhoneNumbers(id);
-    },
+    phoneNumbers: ({ id }, args, { dataSources }) =>
+      dataSources.GroupItem.groupPhoneNumbers(id),
     dateTime: ({ scheduleId }, args, { dataSources }) =>
       dataSources.GroupItem.getDateTimeFromId(scheduleId),
     videoCall: async (root, args, { dataSources }) => {
@@ -108,9 +107,8 @@ const resolver = {
             title,
             url,
           });
-        } else {
-          return dataSources.GroupItem.addResource({ groupId, title, url });
         }
+        return dataSources.GroupItem.addResource({ groupId, title, url });
       } catch (e) {
         console.log({ e });
       }
@@ -129,12 +127,11 @@ const resolver = {
             relatedNodeId,
             contentItemId,
           });
-        } else {
-          return dataSources.GroupItem.addResource({
-            groupId,
-            contentItemId,
-          });
         }
+        return dataSources.GroupItem.addResource({
+          groupId,
+          contentItemId,
+        });
       } catch (e) {
         console.log({ e });
       }
@@ -210,6 +207,15 @@ const resolver = {
       dataSources.GroupItem.getGroupSearchFacetsAttributes(),
     groupFacetFilters: async (root, { facet, facetFilters }, { dataSources }) =>
       dataSources.GroupItem.getGroupFacetsByFilters(facet, facetFilters),
+    groupMemberStatus: (root, { groupId }, { dataSources: { GroupItem } }) => {
+      const globalId = parseGlobalId(groupId);
+
+      if (!globalId.id) {
+        throw new Error(`[groupMemberStatus] Invalid group id provided: ${groupId}`);
+      }
+
+      return GroupItem.getMemberStatus(globalId.id);
+    },
   },
 };
 

--- a/src/data/group-item/schema.js
+++ b/src/data/group-item/schema.js
@@ -18,6 +18,13 @@ export const groupSchema = gql`
     DreamTeam
   }
 
+  enum GROUP_MEMBER_STATUS {
+    OPEN
+    FULL
+    MEMBER
+    PENDING
+  }
+
   type Resource {
     id: String
     title: String
@@ -166,6 +173,7 @@ export const groupSchema = gql`
     groupSearchOptions: GroupSearchFacetsOptions
     groupSearchFacetsAttributes: [String]
     groupFacetFilters(facet: String, facetFilters: [String]): [String]
+    groupMemberStatus(groupId: ID!): GROUP_MEMBER_STATUS
   }
 
   type GroupSearchFacetsOptions {


### PR DESCRIPTION
Schema updates …
152b8ac
* New enum for Group Member Status
OPEN : group can be joined
FULL : group cannot be joined
MEMBER : user is already a member/leader of the group
PENDING : user's member status is pending

* New endpoint for determining a user's status based on the Group Id

## TRADEOFFS
Because this experience is still very new/thrown together last minute, I opted in for a very explicit, low impact way of getting this status. This way we can rip it out much more easily than if it were a first-party field on the Group

------------------------------------------------------------------------------------

Add Group Member Status Logic …
8d62ad5
* Resolver for the schema query
* Logic for actually getting the status of a Group for the interested member
* When attempting to contact a leader/add a member to a group, we will run a check and throw a specific error for the UI to respond accordingly in the case that they should not be added to this group