### PR TITLE
Refine indexing schedules and manual trigger

### DIFF
--- a/src/data/content-item/jobs.js
+++ b/src/data/content-item/jobs.js
@@ -76,27 +76,25 @@ const createJobs = async ({ getContext, queues, trigger = () => null }) => {
   let schedule;
 
   switch (process.env.NODE_ENV) {
-    // Production
+    // Production => 4:00am Every day
     case 'production':
-      // 3:15am Every day
-      schedule = '15 3 * * *';
+      schedule = '0 4 * * *';
       break;
-    // Staging
+    // Staging => 4:00am on Wednesdays
     case 'test':
-      // 3:15am on M/W/F
-      schedule = '15 3 * * 1,3,5';
+      schedule = '0 4 * * 3';
       break;
-    // Dev
+    // Dev => 4:00am Every day
     default:
-      // 3:15am Every Day
-      schedule = '15 3 * * *';
+      schedule = '0 4 * * *';
+      // schedule = '0/5 * * * *'; // Every 5 minutes
       break;
   }
 
   FullIndexQueue.add(null, { repeat: { cron: schedule } });
 
   // add manual index trigger
-  trigger('/manual-index', FullIndexQueue);
+  trigger('/manual-index/content', FullIndexQueue);
 };
 
 export default createJobs;

--- a/src/data/group-item/jobs.js
+++ b/src/data/group-item/jobs.js
@@ -76,27 +76,25 @@ const createJobs = async ({ getContext, queues, trigger = () => null }) => {
   let schedule;
 
   switch (process.env.NODE_ENV) {
-    // Production
+    // Production => 3:00am Every day
     case 'production':
-      // 3:15am Every day
-      schedule = '15 3 * * *';
+      schedule = '0 3 * * *';
       break;
-    // Staging
+    // Staging => 3:00am on Wednesdays
     case 'test':
-      // 3:15am on M/W/F
-      schedule = '15 3 * * 1,3,5';
+      schedule = '0 3 * * 3';
       break;
-    // Dev
+    // Dev => 3:00am Every day
     default:
-      // 3:15am Every Day
-      schedule = '15 3 * * *';
+      schedule = '0 3 * * *';
+      // schedule = '0/5 * * * *'; // Every 5 minutes
       break;
   }
 
   FullIndexQueue.add(null, { repeat: { cron: schedule } });
 
   // add manual index trigger
-  trigger('/manual-index', FullIndexQueue);
+  trigger('/manual-index/groups', FullIndexQueue);
 };
 
 export default createJobs;


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
Updates the schedules for indexing Groups and Content Items, so they don't overlap and occur less often on staging environment.

### 2. What design trade-offs/decisions were made?
None

### 3. How do I test this PR?
Whenever we change the indexing schedules, we need to delete the old ones first. I haven't figured out how to surgically clear _only_ the upcoming scheduled jobs, while preserving past job success/fail history. So I'll open a follow up PR that removes the `deleteJobs()` lines so API deployments don't needlessly throw away job success/fail history.
