### PR TITLE
Algolia user token

### DIFF
--- a/src/data/content-item/resolver.js
+++ b/src/data/content-item/resolver.js
@@ -166,8 +166,11 @@ const resolver = {
         website,
         title
       ),
-    search: async (root, input, { dataSources }) =>
-      dataSources.ContentItem.getSearchIndex().byPaginatedQuery(input),
+    search: async (root, input, { userToken, dataSources }) =>
+      dataSources.ContentItem.getSearchIndex().byPaginatedQuery({
+        userToken,
+        ...input,
+      }),
   },
   Mutation: {
     indexAllContent: async (root, { key, action }, { dataSources }) => {

--- a/src/data/group-item/data-source.js
+++ b/src/data/group-item/data-source.js
@@ -1570,6 +1570,7 @@ export default class GroupItem extends baseGroup.dataSource {
     const searchParams = {
       query: queryText,
       filters: filtersString,
+      userToken: this.context.userToken,
       first,
       after,
     };

--- a/src/data/search/search-index.js
+++ b/src/data/search/search-index.js
@@ -36,7 +36,7 @@ export default class SearchIndex {
     return this.index.clearObjects();
   }
 
-  async byPaginatedQuery({ query, filters, after, first = 20 }) {
+  async byPaginatedQuery({ query, filters, userToken, after, first = 20 }) {
     // Prepare pagination
     const length = first;
     let offset = 0;
@@ -52,7 +52,12 @@ export default class SearchIndex {
     }
 
     // Perform search
-    const results = await this.index.search(query, { filters, length, offset });
+    const results = await this.index.search(query, {
+      filters,
+      userToken,
+      length,
+      offset,
+    });
     const { hits, nbHits: totalResults } = results;
 
     return {


### PR DESCRIPTION
# About

Closes #216 by forwarding the current `userToken` along with the two most important Algolia search paths: Group Finder and Discover.

There are "peripheral" searches like getting the facet options for group finder that were purposefully omitted/not given the `userToken`, as I think that will needlessly muddy analytics later. I feel the most value is in searches where text/filters were manually input, rather than "hidden" searches used to drive UI options without user interaction.

# Testing
Perform content and group searches as an authenticated user and non-authenticated.
They should all work as expected.

Unfortunately there's a bit of a delay on Algolia dashboard, so you can see the `userToken` value being sent by adding a `console.log` in the `byPaginatedQuery` method of `SearchIndex` class (`src/data/search/search-index.js`).