### PR TITLE
Patch hide title content categories

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -325,7 +325,7 @@ ROCK_MAPPINGS:
     HtmlBlock:
       ContentChannelTypeId: [26]
     VerticalCardList:
-      ContentChannelId: [44]
+      ContentChannelId: [44, 87]
 
 CONTENT_CHANNEL_FEEDS:
   HOME_FEED: 64

--- a/src/data/content-item/data-source.js
+++ b/src/data/content-item/data-source.js
@@ -1,16 +1,7 @@
 import ApollosConfig from '@apollosproject/config';
 import { createGlobalId } from '@apollosproject/server-core';
 import { ContentItem as coreContentItem } from '@apollosproject/data-connector-rock';
-import {
-  get,
-  find,
-  kebabCase,
-  take,
-  toLower,
-  upperCase,
-  split,
-  parseInt,
-} from 'lodash';
+import { get, find, kebabCase, take, toLower, upperCase, split, parseInt } from 'lodash';
 import moment from 'moment-timezone';
 import Queue from 'bull';
 import { graphql } from 'graphql';
@@ -115,11 +106,7 @@ export default class ContentItem extends coreContentItem.dataSource {
   sortByAssociationOrder = (associations) => (a, b) => {
     // Check to make sure that associations is an array
     // Check to make sure that a.id and b.id are numbers
-    if (
-      Array.isArray(associations) &&
-      Number.isInteger(a.id) &&
-      Number.isInteger(b.id)
-    ) {
+    if (Array.isArray(associations) && Number.isInteger(a.id) && Number.isInteger(b.id)) {
       const { id: aId } = a;
       const { id: bId } = b;
 
@@ -135,10 +122,7 @@ export default class ContentItem extends coreContentItem.dataSource {
           association.contentChannelItemId === bId
       );
 
-      if (
-        Number.isInteger(associationA.order) &&
-        Number.isInteger(associationB.order)
-      ) {
+      if (Number.isInteger(associationA.order) && Number.isInteger(associationB.order)) {
         return associationA.order - associationB.order;
       }
     }
@@ -284,8 +268,7 @@ export default class ContentItem extends coreContentItem.dataSource {
       }))
       .filter(
         (video) =>
-          video.sources.length > 0 &&
-          !video.sources.find((source) => source.uri === '')
+          video.sources.length > 0 && !video.sources.find((source) => source.uri === '')
       );
   };
 
@@ -302,17 +285,13 @@ export default class ContentItem extends coreContentItem.dataSource {
 
     return find(
       contentItems,
-      (n) =>
-        this.formatTitleAsUrl(get(n, 'title', '')) ===
-        this.formatTitleAsUrl(title)
+      (n) => this.formatTitleAsUrl(get(n, 'title', '')) === this.formatTitleAsUrl(title)
     );
   };
 
-  getContentByTitle = (title) =>
-    this.getByTitle(title, 'BROWSE_CONTENT_CHANNEL_IDS');
+  getContentByTitle = (title) => this.getByTitle(title, 'BROWSE_CONTENT_CHANNEL_IDS');
 
-  getCategoryByTitle = (title) =>
-    this.getByTitle(title, 'CATEGORY_CONTENT_CHANNEL_IDS');
+  getCategoryByTitle = (title) => this.getByTitle(title, 'CATEGORY_CONTENT_CHANNEL_IDS');
 
   getFromTypeIds = (ids) =>
     this.request()
@@ -335,16 +314,12 @@ export default class ContentItem extends coreContentItem.dataSource {
     return Cache.request(
       () =>
         this.request(`ContentChannelItems`)
-          .filterOneOf(
-            contentChannelTypes.map((n) => `ContentChannelTypeId eq ${n}`)
-          )
+          .filterOneOf(contentChannelTypes.map((n) => `ContentChannelTypeId eq ${n}`))
           .andFilter(this.LIVE_CONTENT())
           .select('Id')
           .orderBy('Order')
           .top(limit)
-          .transform((results) =>
-            results.filter((item) => !!item.id).map(({ id }) => id)
-          )
+          .transform((results) => results.filter((item) => !!item.id).map(({ id }) => id))
           .get(),
       {
         key: Cache.KEY_TEMPLATES.eventContentItems,
@@ -366,8 +341,7 @@ export default class ContentItem extends coreContentItem.dataSource {
       return null;
     }
 
-    const usePersonas =
-      FEATURE_FLAGS.ROCK_DYNAMIC_FEED_WITH_PERSONAS.status === 'LIVE';
+    const usePersonas = FEATURE_FLAGS.ROCK_DYNAMIC_FEED_WITH_PERSONAS.status === 'LIVE';
     let personas = [];
     if (usePersonas) {
       try {
@@ -381,9 +355,7 @@ export default class ContentItem extends coreContentItem.dataSource {
     }
 
     const eventIds = await this.getEventContentIds(limit);
-    const contentItems = await Promise.all(
-      eventIds.map((id) => this.getFromId(id))
-    );
+    const contentItems = await Promise.all(eventIds.map((id) => this.getFromId(id)));
 
     return contentItems
       .map((event) => {
@@ -415,9 +387,7 @@ export default class ContentItem extends coreContentItem.dataSource {
     );
 
     return this.request()
-      .filterOneOf(
-        contentChannelTypes.map((n) => `ContentChannelTypeId eq ${n}`)
-      )
+      .filterOneOf(contentChannelTypes.map((n) => `ContentChannelTypeId eq ${n}`))
       .andFilter(this.LIVE_CONTENT())
       .andFilter('Priority gt 0') // featured events have a priority in Rock >0
       .orderBy('Priority', 'desc');
@@ -430,9 +400,7 @@ export default class ContentItem extends coreContentItem.dataSource {
 
     return find(
       contentItems,
-      (n) =>
-        this.formatTitleAsUrl(get(n, 'title', '')) ===
-        this.formatTitleAsUrl(title)
+      (n) => this.formatTitleAsUrl(get(n, 'title', '')) === this.formatTitleAsUrl(title)
     );
   };
 
@@ -494,12 +462,8 @@ export default class ContentItem extends coreContentItem.dataSource {
     if (!associations || !associations.length) return this.request().empty();
 
     return this.getFromIds(
-      associations.map(
-        ({ childContentChannelItemId }) => childContentChannelItemId
-      )
-    ).transform((results) =>
-      results.sort(this.sortByAssociationOrder(associations))
-    );
+      associations.map(({ childContentChannelItemId }) => childContentChannelItemId)
+    ).transform((results) => results.sort(this.sortByAssociationOrder(associations)));
   };
 
   /**
@@ -517,9 +481,7 @@ export default class ContentItem extends coreContentItem.dataSource {
 
     return this.getFromIds(
       associations.map(({ contentChannelItemId }) => contentChannelItemId)
-    ).transform((results) =>
-      results.sort(this.sortByAssociationOrder(associations))
-    );
+    ).transform((results) => results.sort(this.sortByAssociationOrder(associations)));
   };
 
   /**
@@ -532,9 +494,7 @@ export default class ContentItem extends coreContentItem.dataSource {
     const request = async () => {
       const cursor = (await this.getCursorByParentContentItemId(id))
         .expand('ContentChannel')
-        .transform((results) =>
-          results.filter((item) => !!item.id).map(({ id }) => id)
-        );
+        .transform((results) => results.filter((item) => !!item.id).map(({ id }) => id));
 
       return cursor.get();
     };
@@ -681,9 +641,7 @@ export default class ContentItem extends coreContentItem.dataSource {
      *  be active
      */
     if (startDateTime && startDateTime !== '') {
-      const mStartDateTime = moment(startDateTime).tz(
-        ApollosConfig.ROCK.TIMEZONE
-      );
+      const mStartDateTime = moment(startDateTime).tz(ApollosConfig.ROCK.TIMEZONE);
 
       log(
         `${moment().format()} : ${
@@ -812,38 +770,24 @@ export default class ContentItem extends coreContentItem.dataSource {
     // note : get the children of Content Item
     const { Feature } = this.context.dataSources;
     const childrenIds = await this.getChildrenIds(id);
-    const children = await Promise.all(
-      childrenIds.map((id) => this.getFromId(id))
-    );
+    const children = await Promise.all(childrenIds.map((id) => this.getFromId(id)));
 
     const features = await Promise.all(
       children.map((child) => {
-        const { id, contentChannelId, contentChannelTypeId, title } = child;
+        const {
+          id,
+          contentChannelId,
+          contentChannelTypeId,
+          title,
+          attributeValues,
+        } = child;
         let typename = 'ContentBlock';
-
-        // TESTING SOMETHING
-        if (contentChannelId === 87) {
-          return Feature.createVerticalCardListFeature({
-            algorithms: [
-              {
-                type: 'CONTENT_CHILDREN',
-                arguments: {
-                  contentChannelItemId: id,
-                  limit: 0,
-                },
-              },
-            ],
-            title,
-            subtitle: this.createSummary(child),
-          });
-        }
 
         // if we have defined an ContentChannelTypeId based maping in the YML file, use it!
         if (
           Object.values(ROCK_MAPPINGS.FEATURE_MAPPINGS).some(
             ({ ContentChannelTypeId }) =>
-              ContentChannelTypeId &&
-              ContentChannelTypeId.includes(contentChannelTypeId)
+              ContentChannelTypeId && ContentChannelTypeId.includes(contentChannelTypeId)
           )
         ) {
           typename = Object.keys(ROCK_MAPPINGS.FEATURE_MAPPINGS).find((key) => {
@@ -864,8 +808,7 @@ export default class ContentItem extends coreContentItem.dataSource {
           typename = Object.keys(ROCK_MAPPINGS.FEATURE_MAPPINGS).find((key) => {
             const value = ROCK_MAPPINGS.FEATURE_MAPPINGS[key];
             return (
-              value.ContentChannelId &&
-              value.ContentChannelId.includes(contentChannelId)
+              value.ContentChannelId && value.ContentChannelId.includes(contentChannelId)
             );
           });
         }
@@ -916,7 +859,10 @@ export default class ContentItem extends coreContentItem.dataSource {
                   },
                 },
               ],
-              title,
+              title:
+                `${attributeValues?.hideTitle?.value}`.toUpperCase() === 'TRUE'
+                  ? null
+                  : title,
               subtitle: this.createSummary(child),
               primaryAction: {
                 title: 'See More',

--- a/src/data/page-builder/data-source.js
+++ b/src/data/page-builder/data-source.js
@@ -5,7 +5,7 @@ import { isType, isRequired } from '../utils';
 
 export default class PageBuilder extends ContentItem.dataSource {
   async getFeatures(pathname) {
-    const { ContentItem, Feature } = this.context.dataSources;
+    const { Feature } = this.context.dataSources;
 
     const contentItemId = await this.getIdByUrl(pathname);
 
@@ -14,7 +14,7 @@ export default class PageBuilder extends ContentItem.dataSource {
       const children = await Promise.all(childrenIds.map((id) => this.getFromId(id)));
 
       return children.map((child) => {
-        const { id, contentChannelId } = child;
+        const { id, contentChannelId, title, attributeValues } = child;
 
         if (contentChannelId === 87) {
           return Feature.createVerticalCardListFeature({
@@ -32,7 +32,7 @@ export default class PageBuilder extends ContentItem.dataSource {
           });
         }
 
-        return Feature.createContentBlockFeature({ contentChannelItemId });
+        return Feature.createContentBlockFeature({ contentChannelItemId: id });
       });
     }
 


### PR DESCRIPTION
## DESCRIPTION

### 1. What does this PR do, or why is it needed?
When creating a Vertical Card List feature on Content Item features, we will check attribute values to see if the `title` should be hidden. If so, we return the `title` as `null`.

### 2. What design trade-offs/decisions were made?
We only do this check on Feature Feeds generated by the `ContentItem.getFeatures` data-source method. This is so that we don't mess up any of the explicit Feature Feeds (ex. Home, Events, Give, etc), but instead only give the option for a feature on a "Page Builder" page.